### PR TITLE
Fix: use dynamic package version via importlib.metadata

### DIFF
--- a/site_forecast_app/__init__.py
+++ b/site_forecast_app/__init__.py
@@ -1,2 +1,12 @@
 """Site Forecast App."""
-__version__ = "0.0.1"
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    # For Python < 3.8
+    from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("pvnet-app")
+except PackageNotFoundError:
+    __version__ = "v?"
+


### PR DESCRIPTION
# Pull Request

## Description

Replaced the hardcoded `__version__ = "0.0.1"` with dynamic version retrieval using `importlib.metadata`.

Fixes #22 