### PR TITLE
Typo in logging: india instead of site

### DIFF
--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -205,7 +205,7 @@ def app_run(timestamp: dt.datetime | None, write_to_db: bool = False, log_level:
     """Main function for running forecasts for sites."""
     logging.basicConfig(stream=sys.stdout, level=getattr(logging, log_level.upper()))
 
-    log.info(f"Running India forecast app:{version}")
+    log.info(f"Running site forecast app:{version}")
 
     if timestamp is None:
         # get the timestamp now rounded down the nearest 15 minutes


### PR DESCRIPTION
# Pull Request

## Description

Noticed on Airflow that the log still says "Running India forecast app" even in NL tasks, changed it to "site"
