### PR TITLE
chore: remove old data config

### DIFF
--- a/site_forecast_app/models/pvnet/utils.py
+++ b/site_forecast_app/models/pvnet/utils.py
@@ -79,10 +79,6 @@ def populate_data_config_sources(input_path: str, output_path: str) -> dict:
                 "satellite_image_size_pixels_width",
             )
 
-        # Remove any hard coding about satellite delay
-        if "live_delay_minutes" in satellite_config:
-            satellite_config.pop("live_delay_minutes")
-
         # remove any dropout timedeltas
         if "dropout_timedeltas_minutes" in satellite_config:
             satellite_config["dropout_timedeltas_minutes"] = []


### PR DESCRIPTION
# Pull Request

## Description

This PR removes the unused live_delay_minutes field from site_forecast_app/models/pvnet/utils.py.
After searching through:

This repo → only found in utils.py, where it was immediately removed from satellite_config.

Config generation repo → not present.

HuggingFace configs → not present in the satellite section or elsewhere.

Therefore, this field is no longer needed and can safely be removed.

Fixes #74 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
