### PR TITLE
add satellite padding with NaN for delay less than5 minutes

### DIFF
--- a/site_forecast_app/data/satellite.py
+++ b/site_forecast_app/data/satellite.py
@@ -111,7 +111,7 @@ def download_satellite_data(satellite_source_file_path: str,
             # Extend the data with NaNs
             ds = ds.reindex(time=np.concatenate([
                 ds.time,
-                [np.datetime64(latest_satellite_time + pd.Timedelta("5min"))]
+                [np.datetime64(latest_satellite_time + pd.Timedelta("5min"))],
                 ]), fill_value=np.nan)
 
         if scaling_method == "constant":


### PR DESCRIPTION
# Pull Request

## Description

Added padding with NaNs for satellite data to allow the new NL model to run on t0=now, as it expects full availability of the sat data. 

Fixes #86

## How Has This Been Tested?

ran satellite download test locally to check it adds the right timestamp

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
