### PR TITLE
Refactor/extract save forecast

### DIFF
--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -16,9 +16,9 @@ from sqlalchemy.orm import Session
 import site_forecast_app
 from site_forecast_app import __version__
 from site_forecast_app.data.generation import get_generation_data
-from site_forecast_app.save import save_forecast
 from site_forecast_app.models import PVNetModel, get_all_models
 from site_forecast_app.models.pydantic_models import Model
+from site_forecast_app.save import save_forecast
 
 log = logging.getLogger(__name__)
 version = site_forecast_app.__version__

--- a/site_forecast_app/save.py
+++ b/site_forecast_app/save.py
@@ -1,7 +1,11 @@
+"""Functions for saving forecasts."""
+
 import logging
+
 import pandas as pd
-from sqlalchemy.orm import Session
 from pvsite_datamodel.write import insert_forecast_values
+from sqlalchemy.orm import Session
+
 from site_forecast_app.adjuster import adjust_forecast_with_adjuster
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
# Pull Request

## Description

This PR refactors the forecast saving logic by extracting the save_forecast function from app.py into a separate module (save.py).

The goal of this change is to:

- Improve separation of concerns

- Reduce the size and responsibility of app.py

- Make the saving logic easier to maintain and test

- Prepare the codebase for future enhancements to forecast persistence

## How Has This Been Tested?

- Ran the application locally to confirm it starts without import or runtime errors.
- Verified that `save_forecast `is correctly imported from `save.py`.
- Triggered forecast generation and confirmed forecasts are saved successfully.
- Ran all the testcases.


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
