### PR TITLE
add pv+ecmwf summaiton models and retire resnet

### DIFF
--- a/site_forecast_app/models/all_models.yaml
+++ b/site_forecast_app/models/all_models.yaml
@@ -31,15 +31,30 @@ models:
     site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
     location_type: state
     summation_location_type: nation
-  - name: nl_national_pv_ecmwf_sat_resnet
+  - name: nl_regional_48h_pv_ecmwf
     type: pvnet
     id: openclimatefix-models/pvnet_nl
-    version: 1a27240d339b6608f8f883cee37cc62cc9808337
-    site_group_uuid: 4dce2381-9e8d-467e-bbdd-4e342c9e1d89
+    version: ca49693efaeec8154463fc41c03872fd3daa08be
+    summation_id: openclimatefix-models/pvnet_nl
+    summation_version: 5b7f40c9bec763b1d4d8f26e97d66da628ccba66
     client: nl
     asset_type: pv
     satellite_scaling_method: constant
-    location_type: nation
+    site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
+    location_type: state
+    summation_location_type: nation
+  - name: nl_regional_2h_pv_ecmwf
+    type: pvnet
+    id: openclimatefix-models/pvnet_nl
+    version: 6955410dca0c5a60e7881f9333503014f56c13fb
+    summation_id: openclimatefix-models/pvnet_nl
+    summation_version: 296bde7b5af4cf256129800d3bc5013d8b27ffd5
+    client: nl
+    asset_type: pv
+    satellite_scaling_method: constant
+    site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
+    location_type: state
+    summation_location_type: nation
   - name: pvnet_ad_sites_satellite_ecmwf_long_site_history
     type: pvnet
     id: openclimatefix-models/pvnet_ad_sites

--- a/tests/models/test_pydantic_models.py
+++ b/tests/models/test_pydantic_models.py
@@ -6,7 +6,7 @@ from site_forecast_app.models.pydantic_models import Model, get_all_models
 def test_get_all_models():
     """Test for getting all models"""
     models = get_all_models()
-    assert len(models.models) == 11
+    assert len(models.models) == 12
 
 
 def test_site_group_uuid():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -164,13 +164,13 @@ def test_app(
     result = run_click_script(app, args)
     assert result.exit_code == 0
 
-    n_forecasts = 4 + 12
-    n_models = 4
-    # 1 site, 4 models:
-    #   4 models do 36 hours
-    # 1 regional model also does 36 hours for 12 more sites
+    fv_per_hour = 4 # 15 min resolution = 4 values per hour
+    n_forecasts = 5 + 12*3
+    n_models = 5
+    # 1 site, 5 models do 36 hours
+    # 3 regional models also do 36 hours for 12 more sites
     # average number of forecast is:
-    n_fv = ((36 * 16) / n_forecasts) * 4
+    n_fv = ((36 * n_forecasts) / n_forecasts) * fv_per_hour
 
     if write_to_db:
         assert db_session.query(ForecastSQL).count() == init_n_forecasts + n_forecasts * 2


### PR DESCRIPTION
# Pull Request

## Description
Adding ecmwf+pv summation models that use 48 or 2 hours of history. Retiring site resnet model as not been performing in backtesting and site models are deprioritised, to avoid having too many models in live

Amending tests for new number of models & forecasts

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
