### PR TITLE
renamed forecaster name from blend to nl_blend

### DIFF
--- a/site_forecast_app/blend/app.py
+++ b/site_forecast_app/blend/app.py
@@ -239,7 +239,7 @@ async def _save_forecasts(
     # ------------------------------------------------------------------ #
     logger.info(
         f"Saving {n_rows} rows to Data Platform "
-        f"(forecaster='blend', t0={t0}, location='{location_key}') - "
+        f"(forecaster='nl_blend', t0={t0}, location='{location_key}') - "
         f"p50={n_rows}, p10={n_p10}, p90={n_p90} valid rows.",
     )
     try:

--- a/site_forecast_app/blend/config.py
+++ b/site_forecast_app/blend/config.py
@@ -66,7 +66,7 @@ class NlBlendConfig(BaseModel):
         description="Path to the MAE scorecard, relative to the blend package directory.",
     )
     forecaster_name: str = Field(
-        "blend",
+        "nl_blend",
         title="Forecaster Name",
         description="Forecaster name written to the Data Platform.",
     )

--- a/site_forecast_app/blend/config.yaml
+++ b/site_forecast_app/blend/config.yaml
@@ -45,4 +45,4 @@ blend:
   scorecard_path: data/nl_backtest_nmae_comparison.csv
 
   # Forecaster name written to the Data Platform.
-  forecaster_name: blend
+  forecaster_name: nl_blend

--- a/tests/integration/test_nl_app_integration.py
+++ b/tests/integration/test_nl_app_integration.py
@@ -58,7 +58,7 @@ async def test_run_blend_app_e2e(dp_address, monkeypatch):
 
     # 4. Verify the blended forecast was written to the Data Platform.
     list_forecasters_resp = await client.list_forecasters(
-        dp.ListForecastersRequest(forecaster_names_filter=["blend"]),
+        dp.ListForecastersRequest(forecaster_names_filter=["nl_blend"]),
     )
     assert list_forecasters_resp.forecasters, (
         "blend forecaster was not created in the Data Platform."


### PR DESCRIPTION
# Pull Request

## Description

Currently, the forecaster is labeled as `“blend” `for the NL blend, but it should be `“nl_blend.”` This PR updates the forecaster name accordingly, renaming it from `“blend”` to `“nl_blend.`”

Fixes #

## How Has This Been Tested?

This is verified using the Analysis dashboard 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
