### PR TITLE
refactor: refactor blend app to be country-agnostic by injecting conf…

### DIFF
--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -368,7 +368,7 @@ def app_run(
             # run_blend_app so the blend app remains country-agnostic.
             log.info("Checking for blend pipeline configuration...")
             app_config = load_blend_config(client_name=client_name)
-            if app_config and app_config.client_name == client_name and client_name == 'nl':
+            if app_config and app_config.client_name == client_name and client_name == "nl":
                 log.info(f"Starting {app_config.client_name} blend pipeline...")
                 asyncio.run(run_blend_app(config=app_config))
                 log.info(f"{app_config.client_name} blend pipeline completed.")

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -361,15 +361,17 @@ def app_run(
             f"Completed forecasts for {successful_runs} runs for "
             f"{runs} model runs.",
         )
-        if client_name == "nl" and save_to_data_platform:
-            # Run the NL blend pipeline automatically after site forecasts complete.
+        if save_to_data_platform:
+            # Run the generic blend pipeline automatically after site forecasts complete.
             # Blend writes to the Data Platform, so only run when DP saves are enabled.
             # The config is loaded here (where country context lives) and passed into
             # run_blend_app so the blend app remains country-agnostic.
-            log.info("Starting NL blend pipeline...")
-            nl_blend_config = load_blend_config()
-            asyncio.run(run_blend_app(config=nl_blend_config))
-            log.info("NL blend pipeline completed.")
+            log.info("Checking for blend pipeline configuration...")
+            app_config = load_blend_config()
+            if app_config.client_name == client_name:
+                log.info(f"Starting {app_config.client_name} blend pipeline...")
+                asyncio.run(run_blend_app(config=app_config.blend))
+                log.info(f"{app_config.client_name} blend pipeline completed.")
         if successful_runs == runs:
             log.info("All forecasts completed successfully")
         elif 0 < successful_runs < runs:

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session
 import site_forecast_app
 from site_forecast_app import __version__
 from site_forecast_app.blend.app import run_blend_app
+from site_forecast_app.blend.config import load_blend_config
 from site_forecast_app.data.generation import get_generation_data
 from site_forecast_app.models import PVNetModel, get_all_models
 from site_forecast_app.models.pvnet.consts import root_data_path
@@ -363,8 +364,11 @@ def app_run(
         if client_name == "nl" and save_to_data_platform:
             # Run the NL blend pipeline automatically after site forecasts complete.
             # Blend writes to the Data Platform, so only run when DP saves are enabled.
+            # The config is loaded here (where country context lives) and passed into
+            # run_blend_app so the blend app remains country-agnostic.
             log.info("Starting NL blend pipeline...")
-            asyncio.run(run_blend_app())
+            nl_blend_config = load_blend_config()
+            asyncio.run(run_blend_app(config=nl_blend_config))
             log.info("NL blend pipeline completed.")
         if successful_runs == runs:
             log.info("All forecasts completed successfully")

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -367,10 +367,10 @@ def app_run(
             # The config is loaded here (where country context lives) and passed into
             # run_blend_app so the blend app remains country-agnostic.
             log.info("Checking for blend pipeline configuration...")
-            app_config = load_blend_config()
-            if app_config.client_name == client_name:
+            app_config = load_blend_config(client_name=client_name)
+            if app_config and app_config.client_name == client_name and client_name == 'nl':
                 log.info(f"Starting {app_config.client_name} blend pipeline...")
-                asyncio.run(run_blend_app(config=app_config.blend))
+                asyncio.run(run_blend_app(config=app_config))
                 log.info(f"{app_config.client_name} blend pipeline completed.")
         if successful_runs == runs:
             log.info("All forecasts completed successfully")

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -361,14 +361,14 @@ def app_run(
             f"Completed forecasts for {successful_runs} runs for "
             f"{runs} model runs.",
         )
-        if save_to_data_platform:
+        if save_to_data_platform and client_name == "nl":
             # Run the generic blend pipeline automatically after site forecasts complete.
             # Blend writes to the Data Platform, so only run when DP saves are enabled.
             # The config is loaded here (where country context lives) and passed into
             # run_blend_app so the blend app remains country-agnostic.
             log.info("Checking for blend pipeline configuration...")
             app_config = load_blend_config(client_name=client_name)
-            if app_config and app_config.client_name == client_name and client_name == "nl":
+            if app_config and app_config.client_name == client_name:
                 log.info(f"Starting {app_config.client_name} blend pipeline...")
                 asyncio.run(run_blend_app(config=app_config))
                 log.info(f"{app_config.client_name} blend pipeline completed.")

--- a/site_forecast_app/blend/app.py
+++ b/site_forecast_app/blend/app.py
@@ -7,7 +7,7 @@ import pandas as pd
 from dp_sdk.ocf import dp
 
 from site_forecast_app.blend.blend import get_blend_forecast_values_latest
-from site_forecast_app.blend.config import load_blend_config
+from site_forecast_app.blend.config import NlBlendConfig
 from site_forecast_app.blend.data_platform import (
     build_forecast_value_objects,
 )
@@ -22,8 +22,18 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("blend_app")
 
 
-async def run_blend_app() -> None:
-    """Main execution point for the NL Blend app.
+async def run_blend_app(config: NlBlendConfig) -> None:
+    """Main execution point for the forecast blending application.
+
+    The caller is responsible for loading and selecting the correct
+    :class:`~site_forecast_app.blend.config.NlBlendConfig` for the country
+    being processed and passing it in here.  This keeps config selection
+    centralised in the orchestrating ``app.py`` and makes this function
+    reusable for future countries without modification.
+
+    Args:
+        config: A fully-validated blend configuration for the country
+                being processed.
 
     Steps:
     1. Determine blend reference time (t0)
@@ -37,7 +47,7 @@ async def run_blend_app() -> None:
     7. If use_adjuster=True: repeat steps 4-6 using {model}_adjust forecasters
        and save under {forecaster_name}_adjust
     """
-    _cfg = load_blend_config()
+    _cfg = config
     logger.info(
         f"Starting NL Blend execution. "
         f"use_adjuster={_cfg.use_adjuster}, "
@@ -109,6 +119,7 @@ async def run_blend_app() -> None:
             df_mae=df_mae,
             max_horizon=max_horizon,
             forecaster_name=_cfg.forecaster_name,
+            config=_cfg,
         )
 
         # -------------------------------------------------------------- #
@@ -134,6 +145,7 @@ async def run_blend_app() -> None:
                 max_horizon=max_horizon,
                 forecaster_name=_cfg.forecaster_name,
                 use_regional_weights=True,
+                config=_cfg,
             )
 
         # -------------------------------------------------------------- #
@@ -154,6 +166,7 @@ async def run_blend_app() -> None:
                 max_horizon=max_horizon,
                 forecaster_name=_cfg.adjuster_forecaster_name,
                 use_adjuster=True,
+                config=_cfg,
             )
             for location_key, location_uuid in regional_locations.items():
                 await _run_blend_pass(
@@ -166,6 +179,7 @@ async def run_blend_app() -> None:
                     forecaster_name=_cfg.adjuster_forecaster_name,
                     use_adjuster=True,
                     use_regional_weights=True,
+                    config=_cfg,
                 )
 
 
@@ -184,6 +198,7 @@ async def _run_blend_pass(
     df_mae: pd.DataFrame,
     max_horizon: pd.Timedelta,
     forecaster_name: str,
+    config: NlBlendConfig,
     use_adjuster: bool = False,
     use_regional_weights: bool = False,
 ) -> None:
@@ -207,6 +222,7 @@ async def _run_blend_pass(
         df_mae:               (horizon x model) MAE scorecard.
         max_horizon:          Maximum scorecard horizon.
         forecaster_name:      Forecaster tag to save under.
+        config:               Blend configuration (models, kernel, etc.).
         use_adjuster:         When True, fetches {model}_adjust forecasters.
         use_regional_weights: When True, uses regional candidate models for
                               weight optimisation instead of national candidates.
@@ -218,7 +234,6 @@ async def _run_blend_pass(
         f"(forecaster='{forecaster_name}', use_adjuster={use_adjuster})",
     )
 
-    # Weights are always computed from the module-level constants.
     # Regional locations use the regional candidate model set.
     weight_fn = get_regional_blend_weights if use_regional_weights else get_blend_weights
     try:
@@ -228,6 +243,7 @@ async def _run_blend_pass(
             df_mae=df_mae,
             max_horizon=max_horizon,
             client=client,
+            config=config,
         )
         logger.info(f"[{log_prefix}] Blend weights calculated:\n{weights_df.head(10)}")
     except Exception:
@@ -366,4 +382,6 @@ async def _save_forecasts(
 
 
 if __name__ == "__main__":
-    asyncio.run(run_blend_app())
+    from site_forecast_app.blend.config import load_blend_config as _load_cfg
+
+    asyncio.run(run_blend_app(config=_load_cfg()))

--- a/site_forecast_app/blend/app.py
+++ b/site_forecast_app/blend/app.py
@@ -381,7 +381,3 @@ async def _save_forecasts(
         logger.exception(f"Failed to write forecast for '{location_key}'.")
 
 
-if __name__ == "__main__":
-    from site_forecast_app.blend.config import load_blend_config as _load_cfg
-
-    asyncio.run(run_blend_app(config=_load_cfg()))

--- a/site_forecast_app/blend/app.py
+++ b/site_forecast_app/blend/app.py
@@ -55,9 +55,9 @@ async def run_blend_app(config: BlendConfig) -> None:
     )
 
     # ------------------------------------------------------------------ #
-    # Determine blend reference time - floor to 15-min boundary          #
+    # Determine blend reference time (t0) from config                    #
     # ------------------------------------------------------------------ #
-    t0 = pd.Timestamp.utcnow().floor("15min")
+    t0 = config.t0
     logger.info(f"Blend t0: {t0}")
 
     # ------------------------------------------------------------------ #

--- a/site_forecast_app/blend/app.py
+++ b/site_forecast_app/blend/app.py
@@ -1,5 +1,4 @@
 """Main entry point for the NL forecast blending application."""
-import asyncio
 import logging
 import os
 

--- a/site_forecast_app/blend/app.py
+++ b/site_forecast_app/blend/app.py
@@ -7,7 +7,7 @@ import pandas as pd
 from dp_sdk.ocf import dp
 
 from site_forecast_app.blend.blend import get_blend_forecast_values_latest
-from site_forecast_app.blend.config import NlBlendConfig
+from site_forecast_app.blend.config import BlendConfig
 from site_forecast_app.blend.data_platform import (
     build_forecast_value_objects,
 )
@@ -22,11 +22,11 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("blend_app")
 
 
-async def run_blend_app(config: NlBlendConfig) -> None:
+async def run_blend_app(config: BlendConfig) -> None:
     """Main execution point for the forecast blending application.
 
     The caller is responsible for loading and selecting the correct
-    :class:`~site_forecast_app.blend.config.NlBlendConfig` for the country
+    :class:`~site_forecast_app.blend.config.BlendConfig` for the country
     being processed and passing it in here.  This keeps config selection
     centralised in the orchestrating ``app.py`` and makes this function
     reusable for future countries without modification.
@@ -49,7 +49,7 @@ async def run_blend_app(config: NlBlendConfig) -> None:
     """
     _cfg = config
     logger.info(
-        f"Starting NL Blend execution. "
+        "Starting blend execution. "
         f"use_adjuster={_cfg.use_adjuster}, "
         f"forecaster='{_cfg.forecaster_name}'",
     )
@@ -198,7 +198,7 @@ async def _run_blend_pass(
     df_mae: pd.DataFrame,
     max_horizon: pd.Timedelta,
     forecaster_name: str,
-    config: NlBlendConfig,
+    config: BlendConfig,
     use_adjuster: bool = False,
     use_regional_weights: bool = False,
 ) -> None:

--- a/site_forecast_app/blend/config.py
+++ b/site_forecast_app/blend/config.py
@@ -12,8 +12,8 @@ from pyaml_env import parse_config
 from pydantic import BaseModel, Field
 
 
-class NlBlendConfig(BaseModel):
-    """Configuration for the NL Blend blending pipeline."""
+class BlendConfig(BaseModel):
+    """Configuration for a client-specific blend pipeline."""
 
     # ------------------------------------------------------------------
     # Model registry
@@ -115,26 +115,34 @@ class NlBlendConfig(BaseModel):
         return f"{self.forecaster_name}_adjust"
 
 
-class NlBlendConfigWrapper(BaseModel):
-    """Wrapper for the NL Blend configuration."""
+class BlendAppConfig(BaseModel):
+    """Global configuration for the blend application.
 
-    blend: NlBlendConfig
+    Provides a generic trigger mechanism: the blend only runs if
+    the environment's CLIENT_NAME matches ``client_name``.
+    """
+
+    client_name: str = Field(
+        "nl",
+        title="Client Name",
+        description="The name of the client to process (e.g. 'nl').",
+    )
+    blend: BlendConfig
 
 
-def load_blend_config() -> NlBlendConfig:
-    """Load and validate the NL Blend configuration from ``config.yaml``.
+def load_blend_config() -> BlendAppConfig:
+    """Load and validate the blend configuration from ``config.yaml``.
 
     The file is resolved relative to this module so it is always found
-    regardless of the working directory — identical to the approach used
-    by ``site_forecast_app/models/pydantic_models.py``.
+    regardless of the working directory.
 
     Returns:
-        A validated :class:`NlBlendConfig` instance.
+        A validated :class:`BlendAppConfig` instance.
     """
     filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.yaml")
 
     with fsspec.open(filename, mode="r") as stream:
         raw = parse_config(data=stream)
-        wrapper = NlBlendConfigWrapper(**raw)
+        config = BlendAppConfig(**raw)
 
-    return wrapper.blend
+    return config

--- a/site_forecast_app/blend/config.py
+++ b/site_forecast_app/blend/config.py
@@ -56,6 +56,11 @@ class BlendConfig(BaseModel):
         title="Minimum Forecast Horizon (minutes)",
         description="Minimum forecast horizon emitted in any blended forecast.",
     )
+    t0_frequency: str = Field(
+        "15min",
+        title="t0 Floor Frequency",
+        description="The frequency to floor the current time to for the blend reference time (t0).",
+    )
 
     # ------------------------------------------------------------------
     # Adjuster
@@ -113,6 +118,11 @@ class BlendConfig(BaseModel):
     def adjuster_forecaster_name(self) -> str:
         """Forecaster name for the adjusted blend."""
         return f"{self.forecaster_name}_adjust"
+
+    @property
+    def t0(self) -> pd.Timestamp:
+        """The blend reference time (t0), floored to the configured frequency."""
+        return pd.Timestamp.utcnow().floor(self.t0_frequency)
 
 
 class BlendAppConfig(BaseModel):

--- a/site_forecast_app/blend/config.py
+++ b/site_forecast_app/blend/config.py
@@ -15,6 +15,12 @@ from pydantic import BaseModel, Field
 class BlendConfig(BaseModel):
     """Configuration for a client-specific blend pipeline."""
 
+    client_name: str = Field(
+        "nl",
+        title="Client Name",
+        description="The name of the client to process (e.g. 'nl').",
+    )
+
     # ------------------------------------------------------------------
     # Model registry
     # ------------------------------------------------------------------
@@ -125,34 +131,41 @@ class BlendConfig(BaseModel):
         return pd.Timestamp.utcnow().floor(self.t0_frequency)
 
 
-class BlendAppConfig(BaseModel):
-    """Global configuration for the blend application.
+class BlendConfigs(BaseModel):
+    """Global configuration containing all blend configurations."""
 
-    Provides a generic trigger mechanism: the blend only runs if
-    the environment's CLIENT_NAME matches ``client_name``.
-    """
-
-    client_name: str = Field(
-        "nl",
-        title="Client Name",
-        description="The name of the client to process (e.g. 'nl').",
+    blends: list[BlendConfig] = Field(
+        ...,
+        title="Blend Configurations",
+        description="List of all client-specific blend configurations.",
     )
-    blend: BlendConfig
 
 
-def load_blend_config() -> BlendAppConfig:
+def load_blend_config(client_name: str | None = None) -> BlendConfig | None:
     """Load and validate the blend configuration from ``config.yaml``.
 
     The file is resolved relative to this module so it is always found
     regardless of the working directory.
 
+    Args:
+        client_name: The client name to load the configuration for.
+                     If None, it uses the CLIENT_NAME environment variable
+                     (defaulting to "nl").
+
     Returns:
-        A validated :class:`BlendAppConfig` instance.
+        A validated :class:`BlendConfig` instance, or None if no configuration
+        exists for the client.
     """
     filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.yaml")
 
     with fsspec.open(filename, mode="r") as stream:
         raw = parse_config(data=stream)
-        config = BlendAppConfig(**raw)
+        configs = BlendConfigs(**raw)
 
-    return config
+    target_client = client_name or os.getenv("CLIENT_NAME", "nl")
+
+    for blend_cfg in configs.blends:
+        if blend_cfg.client_name == target_client:
+            return blend_cfg
+
+    return None

--- a/site_forecast_app/blend/config.yaml
+++ b/site_forecast_app/blend/config.yaml
@@ -36,6 +36,9 @@ blend:
   # Minimum forecast horizon (minutes) emitted in any blended forecast.
   min_forecast_horizon_minutes: 15
 
+  # Frequency used to floor the blend reference time (t0).
+  t0_frequency: 15min
+
   # ------------------------------------------------------------------ #
   # Adjuster                                                             #
   # ------------------------------------------------------------------ #

--- a/site_forecast_app/blend/config.yaml
+++ b/site_forecast_app/blend/config.yaml
@@ -1,62 +1,63 @@
 # NL Blend configuration
 # Values here drive blend/weights.py and blend/app.py.
-blend:
-  # ------------------------------------------------------------------ #
-  # Model registry                                                       #
-  # ------------------------------------------------------------------ #
+blends:
+  - client_name: nl
+    # ------------------------------------------------------------------ #
+    # Model registry                                                       #
+    # ------------------------------------------------------------------ #
 
-  # The absolute fallback model: always available, used as the backup.
-  backup_model: nl_regional_2h_pv_ecmwf
+    # The absolute fallback model: always available, used as the backup.
+    backup_model: nl_regional_2h_pv_ecmwf
 
-  # Candidate models for the national blend.
-  # The optimiser will pick the single best one to blend against backup_model.
-  national_candidate_models:
-    - nl_regional_48h_pv_ecmwf
-    - nl_regional_pv_ecmwf_mo_sat
-    - nl_regional_pv_ecmwf_sat
-    - nl_national_pv_ecmwf_sat_small
+    # Candidate models for the national blend.
+    # The optimiser will pick the single best one to blend against backup_model.
+    national_candidate_models:
+      - nl_regional_48h_pv_ecmwf
+      - nl_regional_pv_ecmwf_mo_sat
+      - nl_regional_pv_ecmwf_sat
+      - nl_national_pv_ecmwf_sat_small
 
-  # Candidate models for regional blends (subset of national candidates).
-  regional_candidate_models:
-    - nl_regional_48h_pv_ecmwf
-    - nl_regional_pv_ecmwf_mo_sat
-    - nl_regional_pv_ecmwf_sat
+    # Candidate models for regional blends (subset of national candidates).
+    regional_candidate_models:
+      - nl_regional_48h_pv_ecmwf
+      - nl_regional_pv_ecmwf_mo_sat
+      - nl_regional_pv_ecmwf_sat
 
-  # ------------------------------------------------------------------ #
-  # Blending parameters                                                  #
-  # ------------------------------------------------------------------ #
+    # ------------------------------------------------------------------ #
+    # Blending parameters                                                  #
+    # ------------------------------------------------------------------ #
 
-  # Taper kernel: weights at the transition zone between two models.
-  # Values must be strictly between 0 and 1 and non-increasing.
-  blend_kernel:
-    - 0.75
-    - 0.5
-    - 0.25
+    # Taper kernel: weights at the transition zone between two models.
+    # Values must be strictly between 0 and 1 and non-increasing.
+    blend_kernel:
+      - 0.75
+      - 0.5
+      - 0.25
 
-  # Minimum forecast horizon (minutes) emitted in any blended forecast.
-  min_forecast_horizon_minutes: 15
+    # Minimum forecast horizon (minutes) emitted in any blended forecast.
+    min_forecast_horizon_minutes: 15
 
-  # Frequency used to floor the blend reference time (t0).
-  t0_frequency: 15min
+    # Frequency used to floor the blend reference time (t0).
+    t0_frequency: 15min
 
-  # ------------------------------------------------------------------ #
-  # Adjuster                                                             #
-  # ------------------------------------------------------------------ #
-  use_adjuster: true
+    # ------------------------------------------------------------------ #
+    # Adjuster                                                             #
+    # ------------------------------------------------------------------ #
+    use_adjuster: true
 
-  # ------------------------------------------------------------------ #
-  # Infrastructure / naming                                              #
-  # ------------------------------------------------------------------ #
+    # ------------------------------------------------------------------ #
+    # Infrastructure / naming                                              #
+    # ------------------------------------------------------------------ #
 
-  # Path to the MAE scorecard, relative to the blend package directory.
-  scorecard_path: data/nl_backtest_nmae_comparison.csv
+    # Path to the MAE scorecard, relative to the blend package directory.
+    scorecard_path: data/nl_backtest_nmae_comparison.csv
 
-  # Forecaster name written to the Data Platform.
-  forecaster_name: nl_blend
+    # Forecaster name written to the Data Platform.
+    forecaster_name: nl_blend
 
-  # The location name key that identifies the national location in the DP location map.
-  national_location_key: nl_national
+    # The location name key that identifies the national location in the DP location map.
+    national_location_key: nl_national
 
-  # The location type constraint used to filter regional locations from the map.
-  regional_location_type: STATE
+    # The location type constraint used to filter regional locations from the map.
+    regional_location_type: STATE
 

--- a/site_forecast_app/blend/weights.py
+++ b/site_forecast_app/blend/weights.py
@@ -23,7 +23,7 @@ import numpy as np
 import pandas as pd
 from dp_sdk.ocf import dp
 
-from site_forecast_app.blend.config import NlBlendConfig
+from site_forecast_app.blend.config import BlendConfig
 from site_forecast_app.blend.data_platform import fetch_latest_nl_init_times
 from site_forecast_app.blend.init_times import calculate_model_delays, shift_mae_curves
 
@@ -318,7 +318,7 @@ async def get_blend_weights(
     df_mae: pd.DataFrame,
     max_horizon: pd.Timedelta,
     client: dp.DataPlatformDataServiceStub,
-    config: NlBlendConfig,
+    config: BlendConfig,
 ) -> pd.DataFrame:
     """Produces the national blend weight DataFrame for t0.
 
@@ -358,7 +358,7 @@ async def get_regional_blend_weights(
     df_mae: pd.DataFrame,
     max_horizon: pd.Timedelta,
     client: dp.DataPlatformDataServiceStub,
-    config: NlBlendConfig,
+    config: BlendConfig,
 ) -> pd.DataFrame:
     """Produces a regional blend weight DataFrame for t0.
 

--- a/site_forecast_app/blend/weights.py
+++ b/site_forecast_app/blend/weights.py
@@ -23,42 +23,35 @@ import numpy as np
 import pandas as pd
 from dp_sdk.ocf import dp
 
-from site_forecast_app.blend.config import load_blend_config
+from site_forecast_app.blend.config import NlBlendConfig
 from site_forecast_app.blend.data_platform import fetch_latest_nl_init_times
 from site_forecast_app.blend.init_times import calculate_model_delays, shift_mae_curves
 
 logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Load config - all tuning parameters live in blend/config.yaml
-# ---------------------------------------------------------------------------
-_cfg = load_blend_config()
-
-NL_BACKUP_MODEL: str = _cfg.backup_model
-NL_NATIONAL_CANDIDATE_MODELS: list[str] = _cfg.national_candidate_models
-NL_REGIONAL_CANDIDATE_MODELS: list[str] = _cfg.regional_candidate_models
-BLEND_KERNEL: list[float] = _cfg.blend_kernel
-MIN_FORECAST_HORIZON: pd.Timedelta = _cfg.min_forecast_horizon
 
 
 # ---------------------------------------------------------------------------
 # Score function
 # ---------------------------------------------------------------------------
 
-def make_avg_mae_func(horizon: pd.Timedelta) -> Callable[[pd.Series], float]:
+def make_avg_mae_func(
+    horizon: pd.Timedelta,
+    min_forecast_horizon: pd.Timedelta,
+) -> Callable[[pd.Series], float]:
     """Returns a scoring function that averages MAE up to *horizon*.
 
-    Computes the mean MAE over [MIN_FORECAST_HORIZON, horizon], excluding
+    Computes the mean MAE over [min_forecast_horizon, horizon], excluding
     the final boundary point (half-open interval).
 
     Args:
-        horizon: Upper bound of the scoring window (e.g. max_horizon).
+        horizon:              Upper bound of the scoring window (e.g. max_horizon).
+        min_forecast_horizon: Lower bound of the scoring window.
 
     Returns:
         A callable that takes a horizon-MAE Series and returns a float score.
     """
     def _score(horizon_mae: pd.Series) -> float:
-        window = horizon_mae.loc[MIN_FORECAST_HORIZON:horizon]
+        window = horizon_mae.loc[min_forecast_horizon:horizon]
         return float(window.iloc[:-1].mean())
 
     _score.__name__ = f"avg_mae_up_to_{horizon}"
@@ -108,6 +101,7 @@ def calculate_optimal_blend_weights(
     candidate_models: list[str],
     kernel: list[float],
     score_func: Callable[[pd.Series], float],
+    min_forecast_horizon: pd.Timedelta,
 ) -> pd.DataFrame:
     """Selects the single best candidate to blend against the backup.
 
@@ -117,11 +111,12 @@ def calculate_optimal_blend_weights(
     horizon. If no candidate beats the backup, returns backup-only weights.
 
     Args:
-        df_mae:            Shifted (horizon x model) MAE DataFrame.
-        backup_model_name: Column name of the fallback model.
-        candidate_models:  Model names to evaluate (excluding backup).
-        kernel:            Taper kernel (e.g. [0.75, 0.5, 0.25]).
-        score_func:        Callable(pd.Series) -> float, lower is better.
+        df_mae:               Shifted (horizon x model) MAE DataFrame.
+        backup_model_name:    Column name of the fallback model.
+        candidate_models:     Model names to evaluate (excluding backup).
+        kernel:               Taper kernel (e.g. [0.75, 0.5, 0.25]).
+        score_func:           Callable(pd.Series) -> float, lower is better.
+        min_forecast_horizon: Minimum horizon; taper positions below this are skipped.
 
     Returns:
         DataFrame with one or two columns. Weights sum to 1.0 at every
@@ -177,7 +172,7 @@ def calculate_optimal_blend_weights(
             # Sweep taper-start positions over the candidate's valid range.
             max_blend_start_pos = last_non_nan_idx - len(kernel_arr) + 1
             for position in range(max_blend_start_pos + 1):
-                if df_mae.index[position] < MIN_FORECAST_HORIZON:
+                if df_mae.index[position] < min_forecast_horizon:
                     continue
                 candidate_weights = make_blend_weights_array(
                     size=n,
@@ -232,27 +227,33 @@ async def _compute_weights(
     client: dp.DataPlatformDataServiceStub,
     candidate_models: list[str],
     label: str,
+    backup_model: str,
+    kernel: list[float],
+    min_forecast_horizon: pd.Timedelta,
 ) -> pd.DataFrame:
     """Fetches init times, shifts MAE curves, and runs the single-stage optimiser.
 
-    Shared by get_blend_weights
+    Shared by get_blend_weights and get_regional_blend_weights.
 
     Args:
-        t0:               Blend reference time (UTC).
-        location_uuid:    Data Platform location UUID.
-        df_mae:           (horizon x model) MAE scorecard.
-        max_horizon:      Maximum scorecard horizon; used as max_delay and as
-                          the score window upper bound.
-        client:           Authenticated Data Platform gRPC client stub.
-        candidate_models: Models to evaluate against NL_BACKUP_MODEL.
-        label:            Short label for log messages ("National"/"Regional").
+        t0:                   Blend reference time (UTC).
+        location_uuid:        Data Platform location UUID.
+        df_mae:               (horizon x model) MAE scorecard.
+        max_horizon:          Maximum scorecard horizon; used as max_delay and as
+                              the score window upper bound.
+        client:               Authenticated Data Platform gRPC client stub.
+        candidate_models:     Models to evaluate against *backup_model*.
+        label:                Short label for log messages ("National"/"Regional").
+        backup_model:         Fallback model name (always available).
+        kernel:               Taper kernel weights (e.g. [0.75, 0.5, 0.25]).
+        min_forecast_horizon: Minimum forecast horizon used in the scoring window.
 
     Returns:
         Wide DataFrame indexed by absolute UTC target time.
         Weights sum to 1.0 at every horizon.
         Returns an empty DataFrame on failure.
     """
-    all_models = [NL_BACKUP_MODEL, *candidate_models]
+    all_models = [backup_model, *candidate_models]
 
     # Fetch model initialisation times
     model_init_times = await fetch_latest_nl_init_times(
@@ -271,7 +272,7 @@ async def _compute_weights(
     for m in missing:
         # Backup always gets delay=0 (always available).
         # Candidates get delay=max_horizon (effectively excluded).
-        model_init_times[m] = t0 if m == NL_BACKUP_MODEL else t0 - max_horizon
+        model_init_times[m] = t0 if m == backup_model else t0 - max_horizon
 
     # Compute delays and shift MAE scorecard
     delays = calculate_model_delays(model_init_times, t0)
@@ -286,13 +287,14 @@ async def _compute_weights(
         return pd.DataFrame()
 
     # Single-stage optimisation: best candidate vs backup over full horizon
-    score_func = make_avg_mae_func(max_horizon)
+    score_func = make_avg_mae_func(max_horizon, min_forecast_horizon)
     df_weights = calculate_optimal_blend_weights(
         df_mae=df_delayed_mae,
-        backup_model_name=NL_BACKUP_MODEL,
+        backup_model_name=backup_model,
         candidate_models=candidate_models,
-        kernel=BLEND_KERNEL,
+        kernel=kernel,
         score_func=score_func,
+        min_forecast_horizon=min_forecast_horizon,
     )
     logger.info(f"[{label}] Weights (head):\n{df_weights.head()}")
 
@@ -316,11 +318,12 @@ async def get_blend_weights(
     df_mae: pd.DataFrame,
     max_horizon: pd.Timedelta,
     client: dp.DataPlatformDataServiceStub,
+    config: NlBlendConfig,
 ) -> pd.DataFrame:
     """Produces the national blend weight DataFrame for t0.
 
-    Single-stage: picks the best model from NL_NATIONAL_CANDIDATE_MODELS
-    to blend against NL_BACKUP_MODEL, scored over the full scorecard horizon.
+    Single-stage: picks the best model from config.national_candidate_models
+    to blend against config.backup_model, scored over the full scorecard horizon.
 
     Args:
         t0:            Blend reference time (UTC, floored to 15 min).
@@ -328,6 +331,7 @@ async def get_blend_weights(
         df_mae:        (horizon x model) MAE scorecard.
         max_horizon:   Maximum horizon in the scorecard.
         client:        Authenticated Data Platform gRPC client stub.
+        config:        Blend configuration supplying model names and kernel.
 
     Returns:
         Wide DataFrame indexed by absolute UTC target time.
@@ -340,8 +344,11 @@ async def get_blend_weights(
         df_mae=df_mae,
         max_horizon=max_horizon,
         client=client,
-        candidate_models=NL_NATIONAL_CANDIDATE_MODELS,
+        candidate_models=config.national_candidate_models,
         label="National",
+        backup_model=config.backup_model,
+        kernel=config.blend_kernel,
+        min_forecast_horizon=config.min_forecast_horizon,
     )
 
 
@@ -351,12 +358,12 @@ async def get_regional_blend_weights(
     df_mae: pd.DataFrame,
     max_horizon: pd.Timedelta,
     client: dp.DataPlatformDataServiceStub,
+    config: NlBlendConfig,
 ) -> pd.DataFrame:
     """Produces a regional blend weight DataFrame for t0.
 
     Identical pipeline to :func:`get_blend_weights` but uses
-    NL_REGIONAL_CANDIDATE_MODELS as the candidate set, which is typically
-    a subset of the national candidates (see config.yaml).
+    config.regional_candidate_models as the candidate set.
 
     Args:
         t0:            Blend reference time (UTC, floored to 15 min).
@@ -364,6 +371,7 @@ async def get_regional_blend_weights(
         df_mae:        (horizon x model) MAE scorecard.
         max_horizon:   Maximum horizon in the scorecard.
         client:        Authenticated Data Platform gRPC client stub.
+        config:        Blend configuration supplying model names and kernel.
 
     Returns:
         Wide DataFrame indexed by absolute UTC target time.
@@ -376,6 +384,9 @@ async def get_regional_blend_weights(
         df_mae=df_mae,
         max_horizon=max_horizon,
         client=client,
-        candidate_models=NL_REGIONAL_CANDIDATE_MODELS,
+        candidate_models=config.regional_candidate_models,
         label="Regional",
+        backup_model=config.backup_model,
+        kernel=config.blend_kernel,
+        min_forecast_horizon=config.min_forecast_horizon,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from pvsite_datamodel.sqlmodels import (
 from sqlalchemy import create_engine
 from testcontainers.postgres import PostgresContainer
 
+from site_forecast_app.blend.config import BlendConfig, load_blend_config
 from site_forecast_app.data.gencast import get_latest_6hr_init_time
 
 log = logging.getLogger(__name__)
@@ -627,3 +628,9 @@ def small_satellite_data(tmp_path_factory, init_timestamp):
 def use_satellite():
     """Set use satellite env var"""
     os.environ["USE_SATELLITE"] = "true"
+
+
+@pytest.fixture
+def blend_config() -> BlendConfig:
+    """Fixture providing a real BlendConfig populated from config.yaml."""
+    return load_blend_config(client_name="nl")

--- a/tests/integration/test_nl_app_integration.py
+++ b/tests/integration/test_nl_app_integration.py
@@ -55,7 +55,7 @@ async def test_run_blend_app_e2e(dp_address, monkeypatch):
         )
 
     # Also run the full blend pipeline against the stored model forecasts
-    await run_blend_app(config=load_blend_config())
+    await run_blend_app(config=load_blend_config(client_name="nl"))
 
     # 4. Verify the blended forecast was written to the Data Platform.
     list_forecasters_resp = await client.list_forecasters(

--- a/tests/integration/test_nl_app_integration.py
+++ b/tests/integration/test_nl_app_integration.py
@@ -54,8 +54,8 @@ async def test_run_blend_app_e2e(dp_address, monkeypatch):
             n_steps=96,  # 24 h at 15-min resolution
         )
 
-    # 3. Run the blend app.
-    await run_blend_app(config=load_blend_config().blend)
+    # Also run the full blend pipeline against the stored model forecasts
+    await run_blend_app(config=load_blend_config())
 
     # 4. Verify the blended forecast was written to the Data Platform.
     list_forecasters_resp = await client.list_forecasters(

--- a/tests/integration/test_nl_app_integration.py
+++ b/tests/integration/test_nl_app_integration.py
@@ -5,6 +5,7 @@ from dp_sdk.ocf import dp
 from grpclib.client import Channel
 
 from site_forecast_app.blend.app import run_blend_app
+from site_forecast_app.blend.config import load_blend_config
 
 
 @pytest.mark.asyncio
@@ -54,7 +55,7 @@ async def test_run_blend_app_e2e(dp_address, monkeypatch):
         )
 
     # 3. Run the blend app.
-    await run_blend_app()
+    await run_blend_app(config=load_blend_config())
 
     # 4. Verify the blended forecast was written to the Data Platform.
     list_forecasters_resp = await client.list_forecasters(

--- a/tests/integration/test_nl_app_integration.py
+++ b/tests/integration/test_nl_app_integration.py
@@ -5,11 +5,10 @@ from dp_sdk.ocf import dp
 from grpclib.client import Channel
 
 from site_forecast_app.blend.app import run_blend_app
-from site_forecast_app.blend.config import load_blend_config
 
 
 @pytest.mark.asyncio
-async def test_run_blend_app_e2e(dp_address, monkeypatch):
+async def test_run_blend_app_e2e(dp_address, monkeypatch, blend_config):
     """
     End-to-End integration test hitting a real Data Platform test container.
 
@@ -55,7 +54,7 @@ async def test_run_blend_app_e2e(dp_address, monkeypatch):
         )
 
     # Also run the full blend pipeline against the stored model forecasts
-    await run_blend_app(config=load_blend_config(client_name="nl"))
+    await run_blend_app(config=blend_config)
 
     # 4. Verify the blended forecast was written to the Data Platform.
     list_forecasters_resp = await client.list_forecasters(

--- a/tests/integration/test_nl_app_integration.py
+++ b/tests/integration/test_nl_app_integration.py
@@ -55,7 +55,7 @@ async def test_run_blend_app_e2e(dp_address, monkeypatch):
         )
 
     # 3. Run the blend app.
-    await run_blend_app(config=load_blend_config())
+    await run_blend_app(config=load_blend_config().blend)
 
     # 4. Verify the blended forecast was written to the Data Platform.
     list_forecasters_resp = await client.list_forecasters(

--- a/tests/unit/test_blend_config.py
+++ b/tests/unit/test_blend_config.py
@@ -2,20 +2,20 @@
 
 import pytest
 
-from site_forecast_app.blend.config import NlBlendConfig, load_blend_config
+from site_forecast_app.blend.config import BlendConfig, load_blend_config
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _cfg(**overrides) -> NlBlendConfig:
+def _cfg(**overrides) -> BlendConfig:
     """Load the real config.yaml and override specific fields for a test."""
-    return load_blend_config().model_copy(update=overrides)
+    return load_blend_config().blend.model_copy(update=overrides)
 
 
 # ---------------------------------------------------------------------------
-# Tests: NlBlendConfig — adjuster_forecaster_name
+# Tests: BlendConfig — adjuster_forecaster_name
 # ---------------------------------------------------------------------------
 
 
@@ -43,7 +43,7 @@ class TestAdjusterForecasterName:
 
 
 # ---------------------------------------------------------------------------
-# Tests: NlBlendConfig — use_adjuster flag
+# Tests: BlendConfig — use_adjuster flag
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_blend_config.py
+++ b/tests/unit/test_blend_config.py
@@ -2,16 +2,16 @@
 
 import pytest
 
-from site_forecast_app.blend.config import BlendConfig, load_blend_config
+from site_forecast_app.blend.config import BlendConfig
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _cfg(**overrides) -> BlendConfig:
+def _cfg(base_cfg: BlendConfig, **overrides) -> BlendConfig:
     """Load the real config.yaml and override specific fields for a test."""
-    return load_blend_config(client_name="nl").model_copy(update=overrides)
+    return base_cfg.model_copy(update=overrides)
 
 
 # ---------------------------------------------------------------------------
@@ -31,14 +31,14 @@ class TestAdjusterForecasterName:
             ("x", "x_adjust"),
         ],
     )
-    def test_various_forecaster_names(self, forecaster_name, expected):
+    def test_various_forecaster_names(self, blend_config, forecaster_name, expected):
         """adjuster_forecaster_name always appends '_adjust'."""
-        cfg = _cfg(forecaster_name=forecaster_name)
+        cfg = _cfg(blend_config, forecaster_name=forecaster_name)
         assert cfg.adjuster_forecaster_name == expected
 
-    def test_adjuster_name_differs_from_base(self):
+    def test_adjuster_name_differs_from_base(self, blend_config):
         """adjuster_forecaster_name must not equal forecaster_name."""
-        cfg = _cfg()
+        cfg = _cfg(blend_config)
         assert cfg.adjuster_forecaster_name != cfg.forecaster_name
 
 
@@ -50,12 +50,12 @@ class TestAdjusterForecasterName:
 class TestUseAdjusterFlag:
     """Tests for the use_adjuster config flag."""
 
-    def test_use_adjuster_is_configurable_true(self):
+    def test_use_adjuster_is_configurable_true(self, blend_config):
         """use_adjuster=True round-trips through the model."""
-        cfg = _cfg(use_adjuster=True)
+        cfg = _cfg(blend_config, use_adjuster=True)
         assert cfg.use_adjuster is True
 
-    def test_use_adjuster_is_configurable_false(self):
+    def test_use_adjuster_is_configurable_false(self, blend_config):
         """use_adjuster=False can be set regardless of config.yaml default."""
-        cfg = _cfg(use_adjuster=False)
+        cfg = _cfg(blend_config, use_adjuster=False)
         assert cfg.use_adjuster is False

--- a/tests/unit/test_blend_config.py
+++ b/tests/unit/test_blend_config.py
@@ -11,7 +11,7 @@ from site_forecast_app.blend.config import BlendConfig, load_blend_config
 
 def _cfg(**overrides) -> BlendConfig:
     """Load the real config.yaml and override specific fields for a test."""
-    return load_blend_config().model_copy(update=overrides)
+    return load_blend_config(client_name="nl").model_copy(update=overrides)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_blend_config.py
+++ b/tests/unit/test_blend_config.py
@@ -11,7 +11,7 @@ from site_forecast_app.blend.config import BlendConfig, load_blend_config
 
 def _cfg(**overrides) -> BlendConfig:
     """Load the real config.yaml and override specific fields for a test."""
-    return load_blend_config().blend.model_copy(update=overrides)
+    return load_blend_config().model_copy(update=overrides)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_nl_app.py
+++ b/tests/unit/test_nl_app.py
@@ -7,7 +7,6 @@ import pytest
 from dp_sdk.ocf import dp
 
 from site_forecast_app.blend.app import rename_columns_with_adjuster, run_blend_app
-from site_forecast_app.blend.config import load_blend_config
 
 # ---------------------------------------------------------------------------
 # Unit tests for the NL blend application orchestration
@@ -73,7 +72,7 @@ def _mock_scorecard() -> pd.DataFrame:
     )
 
 @pytest.mark.asyncio
-async def test_run_blend_app_success(mock_dependencies):
+async def test_run_blend_app_success(mock_dependencies, blend_config):
     """Test full execution path: both main blend and adjuster pass run (use_adjuster=True)."""
     deps = mock_dependencies
 
@@ -97,7 +96,7 @@ async def test_run_blend_app_success(mock_dependencies):
     mock_blend_df.loc[0] = [pd.Timestamp("2024-01-01 12:00", tz="UTC"), 10.0]
     deps["get_blend_forecast_values_latest"].return_value = mock_blend_df
 
-    await run_blend_app(config=load_blend_config(client_name="nl"))
+    await run_blend_app(config=blend_config)
 
     # These are called once per run (shared setup)
     deps["load_nl_mae_scorecard"].assert_called_once()
@@ -118,19 +117,19 @@ async def test_run_blend_app_success(mock_dependencies):
     )
 
 @pytest.mark.asyncio
-async def test_run_blend_app_aborts_on_empty_location(caplog, mock_dependencies):  # noqa: ARG001
+async def test_run_blend_app_aborts_on_empty_location(caplog, mock_dependencies, blend_config):  # noqa: ARG001
     """Test early exit if no location map is returned."""
     # We do not seed any locations here, so list_locations will return empty.
 
     with caplog.at_level(logging.ERROR, logger="blend_app"):
-        await run_blend_app(config=load_blend_config(client_name="nl"))
+        await run_blend_app(config=blend_config)
 
     assert "empty location map" in caplog.text
 
 
 
 @pytest.mark.asyncio
-async def test_run_blend_app_aborts_on_empty_blend(caplog, mock_dependencies):
+async def test_run_blend_app_aborts_on_empty_blend(caplog, mock_dependencies, blend_config):
     """Test safe exit without saving if no blended forecasts are generated."""
     deps = mock_dependencies
 
@@ -152,7 +151,7 @@ async def test_run_blend_app_aborts_on_empty_blend(caplog, mock_dependencies):
     deps["get_blend_forecast_values_latest"].return_value = pd.DataFrame()
 
     with caplog.at_level(logging.WARNING, logger="site_forecast_app.blend.blend"):
-        await run_blend_app(config=load_blend_config(client_name="nl"))
+        await run_blend_app(config=blend_config)
 
     deps["_save_forecasts"].assert_not_called()
 
@@ -187,7 +186,7 @@ class TestRenameColumnsWithAdjuster:
         assert list(df.columns) == ["model_A"]
 
 @pytest.mark.asyncio
-async def test_run_blend_app_filters_regional_locations(mock_dependencies):
+async def test_run_blend_app_filters_regional_locations(mock_dependencies, blend_config):
     """Test that regional blends are only run for locations starting with 'nl_'."""
     deps = mock_dependencies
 
@@ -243,7 +242,7 @@ async def test_run_blend_app_filters_regional_locations(mock_dependencies):
     mock_blend_df.loc[0] = [pd.Timestamp("2024-01-01 12:00", tz="UTC"), 10.0]
     deps["get_blend_forecast_values_latest"].return_value = mock_blend_df
 
-    await run_blend_app(config=load_blend_config(client_name="nl"))
+    await run_blend_app(config=blend_config)
 
     # Should run main blend and adjuster for:
     # 1. nl_national (National pass) -> uses get_blend_weights (2 calls)

--- a/tests/unit/test_nl_app.py
+++ b/tests/unit/test_nl_app.py
@@ -7,6 +7,7 @@ import pytest
 from dp_sdk.ocf import dp
 
 from site_forecast_app.blend.app import rename_columns_with_adjuster, run_blend_app
+from site_forecast_app.blend.config import load_blend_config
 
 # ---------------------------------------------------------------------------
 # Unit tests for the NL blend application orchestration
@@ -96,7 +97,7 @@ async def test_run_blend_app_success(mock_dependencies):
     mock_blend_df.loc[0] = [pd.Timestamp("2024-01-01 12:00", tz="UTC"), 10.0]
     deps["get_blend_forecast_values_latest"].return_value = mock_blend_df
 
-    await run_blend_app()
+    await run_blend_app(config=load_blend_config())
 
     # These are called once per run (shared setup)
     deps["load_nl_mae_scorecard"].assert_called_once()
@@ -122,7 +123,7 @@ async def test_run_blend_app_aborts_on_empty_location(caplog, mock_dependencies)
     # We do not seed any locations here, so list_locations will return empty.
 
     with caplog.at_level(logging.ERROR, logger="blend_app"):
-        await run_blend_app()
+        await run_blend_app(config=load_blend_config())
 
     assert "empty location map" in caplog.text
 
@@ -151,7 +152,7 @@ async def test_run_blend_app_aborts_on_empty_blend(caplog, mock_dependencies):
     deps["get_blend_forecast_values_latest"].return_value = pd.DataFrame()
 
     with caplog.at_level(logging.WARNING, logger="site_forecast_app.blend.blend"):
-        await run_blend_app()
+        await run_blend_app(config=load_blend_config())
 
     deps["_save_forecasts"].assert_not_called()
 
@@ -242,7 +243,7 @@ async def test_run_blend_app_filters_regional_locations(mock_dependencies):
     mock_blend_df.loc[0] = [pd.Timestamp("2024-01-01 12:00", tz="UTC"), 10.0]
     deps["get_blend_forecast_values_latest"].return_value = mock_blend_df
 
-    await run_blend_app()
+    await run_blend_app(config=load_blend_config())
 
     # Should run main blend and adjuster for:
     # 1. nl_national (National pass) -> uses get_blend_weights (2 calls)

--- a/tests/unit/test_nl_app.py
+++ b/tests/unit/test_nl_app.py
@@ -97,7 +97,7 @@ async def test_run_blend_app_success(mock_dependencies):
     mock_blend_df.loc[0] = [pd.Timestamp("2024-01-01 12:00", tz="UTC"), 10.0]
     deps["get_blend_forecast_values_latest"].return_value = mock_blend_df
 
-    await run_blend_app(config=load_blend_config())
+    await run_blend_app(config=load_blend_config(client_name="nl"))
 
     # These are called once per run (shared setup)
     deps["load_nl_mae_scorecard"].assert_called_once()
@@ -123,7 +123,7 @@ async def test_run_blend_app_aborts_on_empty_location(caplog, mock_dependencies)
     # We do not seed any locations here, so list_locations will return empty.
 
     with caplog.at_level(logging.ERROR, logger="blend_app"):
-        await run_blend_app(config=load_blend_config())
+        await run_blend_app(config=load_blend_config(client_name="nl"))
 
     assert "empty location map" in caplog.text
 
@@ -152,7 +152,7 @@ async def test_run_blend_app_aborts_on_empty_blend(caplog, mock_dependencies):
     deps["get_blend_forecast_values_latest"].return_value = pd.DataFrame()
 
     with caplog.at_level(logging.WARNING, logger="site_forecast_app.blend.blend"):
-        await run_blend_app(config=load_blend_config())
+        await run_blend_app(config=load_blend_config(client_name="nl"))
 
     deps["_save_forecasts"].assert_not_called()
 
@@ -243,7 +243,7 @@ async def test_run_blend_app_filters_regional_locations(mock_dependencies):
     mock_blend_df.loc[0] = [pd.Timestamp("2024-01-01 12:00", tz="UTC"), 10.0]
     deps["get_blend_forecast_values_latest"].return_value = mock_blend_df
 
-    await run_blend_app(config=load_blend_config())
+    await run_blend_app(config=load_blend_config(client_name="nl"))
 
     # Should run main blend and adjuster for:
     # 1. nl_national (National pass) -> uses get_blend_weights (2 calls)

--- a/tests/unit/test_nl_app.py
+++ b/tests/unit/test_nl_app.py
@@ -97,7 +97,7 @@ async def test_run_blend_app_success(mock_dependencies):
     mock_blend_df.loc[0] = [pd.Timestamp("2024-01-01 12:00", tz="UTC"), 10.0]
     deps["get_blend_forecast_values_latest"].return_value = mock_blend_df
 
-    await run_blend_app(config=load_blend_config().blend)
+    await run_blend_app(config=load_blend_config())
 
     # These are called once per run (shared setup)
     deps["load_nl_mae_scorecard"].assert_called_once()
@@ -123,7 +123,7 @@ async def test_run_blend_app_aborts_on_empty_location(caplog, mock_dependencies)
     # We do not seed any locations here, so list_locations will return empty.
 
     with caplog.at_level(logging.ERROR, logger="blend_app"):
-        await run_blend_app(config=load_blend_config().blend)
+        await run_blend_app(config=load_blend_config())
 
     assert "empty location map" in caplog.text
 
@@ -152,7 +152,7 @@ async def test_run_blend_app_aborts_on_empty_blend(caplog, mock_dependencies):
     deps["get_blend_forecast_values_latest"].return_value = pd.DataFrame()
 
     with caplog.at_level(logging.WARNING, logger="site_forecast_app.blend.blend"):
-        await run_blend_app(config=load_blend_config().blend)
+        await run_blend_app(config=load_blend_config())
 
     deps["_save_forecasts"].assert_not_called()
 
@@ -243,7 +243,7 @@ async def test_run_blend_app_filters_regional_locations(mock_dependencies):
     mock_blend_df.loc[0] = [pd.Timestamp("2024-01-01 12:00", tz="UTC"), 10.0]
     deps["get_blend_forecast_values_latest"].return_value = mock_blend_df
 
-    await run_blend_app(config=load_blend_config().blend)
+    await run_blend_app(config=load_blend_config())
 
     # Should run main blend and adjuster for:
     # 1. nl_national (National pass) -> uses get_blend_weights (2 calls)

--- a/tests/unit/test_nl_app.py
+++ b/tests/unit/test_nl_app.py
@@ -97,7 +97,7 @@ async def test_run_blend_app_success(mock_dependencies):
     mock_blend_df.loc[0] = [pd.Timestamp("2024-01-01 12:00", tz="UTC"), 10.0]
     deps["get_blend_forecast_values_latest"].return_value = mock_blend_df
 
-    await run_blend_app(config=load_blend_config())
+    await run_blend_app(config=load_blend_config().blend)
 
     # These are called once per run (shared setup)
     deps["load_nl_mae_scorecard"].assert_called_once()
@@ -123,7 +123,7 @@ async def test_run_blend_app_aborts_on_empty_location(caplog, mock_dependencies)
     # We do not seed any locations here, so list_locations will return empty.
 
     with caplog.at_level(logging.ERROR, logger="blend_app"):
-        await run_blend_app(config=load_blend_config())
+        await run_blend_app(config=load_blend_config().blend)
 
     assert "empty location map" in caplog.text
 
@@ -152,7 +152,7 @@ async def test_run_blend_app_aborts_on_empty_blend(caplog, mock_dependencies):
     deps["get_blend_forecast_values_latest"].return_value = pd.DataFrame()
 
     with caplog.at_level(logging.WARNING, logger="site_forecast_app.blend.blend"):
-        await run_blend_app(config=load_blend_config())
+        await run_blend_app(config=load_blend_config().blend)
 
     deps["_save_forecasts"].assert_not_called()
 
@@ -243,7 +243,7 @@ async def test_run_blend_app_filters_regional_locations(mock_dependencies):
     mock_blend_df.loc[0] = [pd.Timestamp("2024-01-01 12:00", tz="UTC"), 10.0]
     deps["get_blend_forecast_values_latest"].return_value = mock_blend_df
 
-    await run_blend_app(config=load_blend_config())
+    await run_blend_app(config=load_blend_config().blend)
 
     # Should run main blend and adjuster for:
     # 1. nl_national (National pass) -> uses get_blend_weights (2 calls)

--- a/tests/unit/test_nl_weights.py
+++ b/tests/unit/test_nl_weights.py
@@ -9,8 +9,8 @@ from site_forecast_app.blend.weights import get_blend_weights
 
 @pytest.fixture
 def blend_config() -> BlendConfig:
-    """Real BlendConfig loaded from config.yaml."""
-    return load_blend_config().blend
+    """Fixture providing a real BlendConfig populated from config.yaml."""
+    return load_blend_config()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_nl_weights.py
+++ b/tests/unit/test_nl_weights.py
@@ -10,7 +10,7 @@ from site_forecast_app.blend.weights import get_blend_weights
 @pytest.fixture
 def blend_config() -> BlendConfig:
     """Fixture providing a real BlendConfig populated from config.yaml."""
-    return load_blend_config()
+    return load_blend_config(client_name="nl")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_nl_weights.py
+++ b/tests/unit/test_nl_weights.py
@@ -3,14 +3,22 @@ from unittest.mock import AsyncMock, patch
 import pandas as pd
 import pytest
 
+from site_forecast_app.blend.config import NlBlendConfig, load_blend_config
 from site_forecast_app.blend.weights import get_blend_weights
+
+
+@pytest.fixture
+def blend_config() -> NlBlendConfig:
+    """Real NlBlendConfig loaded from config.yaml."""
+    return load_blend_config()
+
 
 # ---------------------------------------------------------------------------
 # Tests for get_blend_weights
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_get_blend_weights_missing_init_times():
+async def test_get_blend_weights_missing_init_times(blend_config: NlBlendConfig):
     """Verify weights fallback to penalty logic when models missing."""
     t0 = pd.Timestamp("2024-06-01 12:00", tz="UTC")
     location_uuid = "test-uuid"
@@ -44,6 +52,7 @@ async def test_get_blend_weights_missing_init_times():
             df_mae=df_mae,
             max_horizon=max_horizon,
             client=mock_client,
+            config=blend_config,
         )
 
     assert weights_df is not None
@@ -56,8 +65,9 @@ async def test_get_blend_weights_missing_init_times():
     weight_sum = weights_df.sum(axis=1)
     assert (weight_sum > 0.99).all() and (weight_sum < 1.01).all()
 
+
 @pytest.mark.asyncio
-async def test_get_blend_weights_all_fail():
+async def test_get_blend_weights_all_fail(blend_config: NlBlendConfig):
     """Verify fallback when no initialisation times exist (everything falls back)."""
     t0 = pd.Timestamp("2024-06-01 12:00", tz="UTC")
     df_mae = pd.DataFrame({"nl_regional_2h_pv_ecmwf": [1.0]}, index=[pd.Timedelta("30min")])
@@ -74,6 +84,7 @@ async def test_get_blend_weights_all_fail():
             df_mae=df_mae,
             max_horizon=pd.Timedelta("30min"),
             client=AsyncMock(),
+            config=blend_config,
         )
         assert len(weights_df) == 1
         # It still computes weights evenly or heavily shifts since they both have huge penalties.

--- a/tests/unit/test_nl_weights.py
+++ b/tests/unit/test_nl_weights.py
@@ -3,15 +3,8 @@ from unittest.mock import AsyncMock, patch
 import pandas as pd
 import pytest
 
-from site_forecast_app.blend.config import BlendConfig, load_blend_config
+from site_forecast_app.blend.config import BlendConfig
 from site_forecast_app.blend.weights import get_blend_weights
-
-
-@pytest.fixture
-def blend_config() -> BlendConfig:
-    """Fixture providing a real BlendConfig populated from config.yaml."""
-    return load_blend_config(client_name="nl")
-
 
 # ---------------------------------------------------------------------------
 # Tests for get_blend_weights

--- a/tests/unit/test_nl_weights.py
+++ b/tests/unit/test_nl_weights.py
@@ -3,14 +3,14 @@ from unittest.mock import AsyncMock, patch
 import pandas as pd
 import pytest
 
-from site_forecast_app.blend.config import NlBlendConfig, load_blend_config
+from site_forecast_app.blend.config import BlendConfig, load_blend_config
 from site_forecast_app.blend.weights import get_blend_weights
 
 
 @pytest.fixture
-def blend_config() -> NlBlendConfig:
-    """Real NlBlendConfig loaded from config.yaml."""
-    return load_blend_config()
+def blend_config() -> BlendConfig:
+    """Real BlendConfig loaded from config.yaml."""
+    return load_blend_config().blend
 
 
 # ---------------------------------------------------------------------------
@@ -18,7 +18,7 @@ def blend_config() -> NlBlendConfig:
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_get_blend_weights_missing_init_times(blend_config: NlBlendConfig):
+async def test_get_blend_weights_missing_init_times(blend_config: BlendConfig):
     """Verify weights fallback to penalty logic when models missing."""
     t0 = pd.Timestamp("2024-06-01 12:00", tz="UTC")
     location_uuid = "test-uuid"
@@ -67,7 +67,7 @@ async def test_get_blend_weights_missing_init_times(blend_config: NlBlendConfig)
 
 
 @pytest.mark.asyncio
-async def test_get_blend_weights_all_fail(blend_config: NlBlendConfig):
+async def test_get_blend_weights_all_fail(blend_config: BlendConfig):
     """Verify fallback when no initialisation times exist (everything falls back)."""
     t0 = pd.Timestamp("2024-06-01 12:00", tz="UTC")
     df_mae = pd.DataFrame({"nl_regional_2h_pv_ecmwf": [1.0]}, index=[pd.Timedelta("30min")])


### PR DESCRIPTION
# Pull Request

## Description

Refactors the NL forecast blending pipeline to be country-agnostic by injecting `BlendConfig` as an explicit parameter into the core execution functions, replacing hardcoded module-level constants (`NL_BACKUP_MODEL`, `NL_NATIONAL_CANDIDATE_MODELS`, `NL_REGIONAL_CANDIDATE_MODELS`).

- `get_blend_weights` and `get_regional_blend_weights` in `blend/weights.py` now accept `config: NlBlendConfig` and read all model names, kernel, and horizon settings from it.
- `run_blend_app` in `blend/app.py` accepts `config: NlBlendConfig` and passes it down to all weight and adjuster calls.
- The top-level `app.py` loads config once via `load_blend_config()` and injects it.
- All unit and integration test call sites updated to pass `config=load_blend_config()`.
- `test_nl_weights.py` gains a `blend_config` fixture backed by the real `config.yaml` via `load_blend_config()`.

Fixes #

## How Has This Been Tested?

- Unit tests in `tests/unit/test_nl_weights.py` covering weight fallback logic when models have missing or absent init times.
- Unit tests in `tests/unit/test_nl_app.py` covering full orchestration: national + regional blend passes, adjuster pass, empty-location abort, and empty-blend abort.
- Integration test in `tests/integration/test_nl_app_integration.py` run end-to-end against a live Data Platform container.
- Tested Against Dev DP

- [x] Yes

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
