### PR TITLE
Curtailment

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ The main application (`blend/app.py`):
 3. Saves the blended forecast to the Data Platform ready to be used by the API
 4. This is done for the national location
 
+## NL Curtialment 
+
+We've added an optional for the NL forecast to model curtailment. We do this by 
+1. Loading in uncrtailed generation values
+2. Run the forecast
+3. If the DA NL prices are negative, we reduce the forecast by 11%. 
+
 ### Details
 
 The blend is created by selecting the candidate model with the lowest expected MAE (whilst also

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ The main application (`blend/app.py`):
 
 ## NL Curtialment 
 
-We've added an optional for the NL forecast to model curtailment. We do this by 
-1. Loading in uncrtailed generation values
+We've added an option for the NL forecast to model curtailment. We do this by 
+1. Loading in uncurtailed generation values
 2. Run the forecast
 3. If the DA NL prices are negative, we reduce the forecast by 11%. 
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The main application (`blend/app.py`):
 3. Saves the blended forecast to the Data Platform ready to be used by the API
 4. This is done for the national location
 
-## NL Curtialment 
+## NL Curtailment 
 
 We've added an option for the NL forecast to model curtailment. We do this by 
 1. Loading in uncurtailed generation values

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "dp-sdk",
     "gcsfs==2025.10.0",
     "xesmf==0.9.2", # Requires ESMF to be installed
+    "entsoe-py>=0.8.0",
 ]
 
 [dependency-groups]

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -266,16 +266,17 @@ def app_run(
                     timestamp=timestamp,
                 )
 
-                if model_config.curtailment:
-                    log.info("Applying curtailment to forecast values...")
-                    forecast_values = {k: curtailment.apply_curtailment(v) \
-                                       for k, v in forecast_values.items()}
-
                 if forecast_values is None:
                     log.info(
                         f"No forecast values for site_group_uuid={model_config.site_group_uuid}",
                     )
                 else:
+
+                    if model_config.curtailment:
+                        log.info("Applying curtailment to forecast values...")
+                        forecast_values = {k: curtailment.apply_curtailment(v) \
+                                        for k, v in forecast_values.items()}
+
                     # 4. Write forecast to DB or stdout
                     log.info(
                         f"Writing forecast for site_group_uuid={model_config.site_group_uuid}",

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -268,7 +268,7 @@ def app_run(
 
                 if model_config.curtailment:
                     log.info("Applying curtailment to forecast values...")
-                    forecast_values = curtailment.apply_curtailment(forecast_values)
+                    forecast_values = {k: curtailment.apply_curtailment(v) for k, v in forecast_values.items()}
 
                 if forecast_values is None:
                     log.info(

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -20,6 +20,7 @@ import site_forecast_app
 from site_forecast_app import __version__
 from site_forecast_app.blend.app import run_blend_app
 from site_forecast_app.blend.config import load_blend_config
+from site_forecast_app.curtailment import Curtailment
 from site_forecast_app.data.generation import get_generation_data
 from site_forecast_app.models import PVNetModel, get_all_models
 from site_forecast_app.models.pvnet.consts import root_data_path
@@ -208,6 +209,11 @@ def app_run(
                     "Failed to pre-fetch DP location map — will fall back to per-site lookup.",
                     exc_info=True,
                 )
+
+        if any(m.curtailment for m in all_model_configs.models):
+            log.info("Curtailment is enabled for at least one model.")
+            curtailment = Curtailment(timestamp)
+
         for model_config in all_model_configs.models:
             # 2. Get sites
             log.info("Getting sites...")
@@ -257,6 +263,10 @@ def app_run(
                     model=ml_model,
                     timestamp=timestamp,
                 )
+
+                if model_config.curtailment:
+                    log.info("Applying curtailment to forecast values...")
+                    forecast_values = curtailment.apply_curtailment(forecast_values)
 
                 if forecast_values is None:
                     log.info(

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -268,7 +268,8 @@ def app_run(
 
                 if model_config.curtailment:
                     log.info("Applying curtailment to forecast values...")
-                    forecast_values = {k: curtailment.apply_curtailment(v) for k, v in forecast_values.items()}
+                    forecast_values = {k: curtailment.apply_curtailment(v) \
+                                       for k, v in forecast_values.items()}
 
                 if forecast_values is None:
                     log.info(

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -368,6 +368,7 @@ def app_run(
                             ml_model_version=version,
                             location_map=dp_location_map,
                             use_adjuster_database=use_adjuster_database,
+                            observer_name=model_config.observer_name_adjuster,
                         )
                         successful_runs += 1
 

--- a/site_forecast_app/curtailment.py
+++ b/site_forecast_app/curtailment.py
@@ -20,7 +20,6 @@ class Curtailment:
 
     def get_prices(self) -> None:
         """Fetch the latest market prices for curtailment."""
-        # TODO
         client = EntsoePandasClient(api_key=api_key)
         country_code = "NL"  # Netherlands
         start = self.now
@@ -34,12 +33,10 @@ class Curtailment:
         # validate data
         if data.empty:
             log.warning("No data returned from ENTSOE API.")
-            return pd.DataFrame()
 
         # check there are not nans
         if data.isnull().values.any():
             log.warning("Data contains NaNs.")
-            return pd.DataFrame()
 
         # make sure timezone is utc
         data.index = data.index.tz_convert("UTC")
@@ -51,13 +48,17 @@ class Curtailment:
 
         self.prices_df = data
 
-    def apply_curtailment(self, forecast_values: dict) -> dict:
+    def apply_curtailment(self, forecast_values: dict | None) -> dict | None:
         """Apply curtailment to the forecast values.
 
         This is v1 curtailment for NL.
         If the prices are negative, then we reduce the values by 11%.
         """
-        if len(forecast_values):
+        # for forecast values is None, then also return None
+        if forecast_values is None:
+            return forecast_values
+
+        if len(forecast_values) == 0:
             return forecast_values
 
         # make into dataframe and merge with prices
@@ -70,8 +71,8 @@ class Curtailment:
         forecast_values_df["curtailed"] = forecast_values_df[
             "NL_day_ahead_prices_euros_per_mwh"
         ].apply(lambda x: x < 0)
-        forecast_values_df["forecast_value"] = forecast_values_df.apply(
-            lambda row: row["forecast_value"] / 1.11 if row["curtailed"] else row["forecast_value"],
+        forecast_values_df["forecast_power_kw"] = forecast_values_df.apply(
+            lambda row: row["forecast_power_kw"] / 1.11 if row["curtailed"] else row["forecast_power_kw"],
             axis=1,
         )
 

--- a/site_forecast_app/curtailment.py
+++ b/site_forecast_app/curtailment.py
@@ -26,7 +26,7 @@ class Curtailment:
         # make sure start has a timezone
         if start.tzinfo is None:
             start = start.tz_localize("UTC")
-        end = start + pd.Timedelta(days=2)  # fetch a week of data
+        end = start + pd.Timedelta(days=2)  # fetch a 2 days of data
 
         # methods that return Pandas Series
         log.info(f"Fetching day-ahead prices from ENTSOE API for {country_code} \

--- a/site_forecast_app/curtailment.py
+++ b/site_forecast_app/curtailment.py
@@ -1,0 +1,76 @@
+"""Class for managing curtailment forecasts."""
+
+import logging
+import os
+
+import pandas as pd
+from entsoe import EntsoePandasClient
+
+log = logging.getLogger(__name__)
+
+api_key = os.getenv("APIKEY_ENTSOE")
+
+
+class Curtailment:
+    """Curtailment class for managing curtailment forecasts."""
+    def __init__(self, now: pd.Timestamp) -> None:
+        """Initialize the Curtailment class by getting NL DA prices."""
+        self.now = now
+        self.get_prices()
+
+    def get_prices(self) -> None:
+        """Fetch the latest market prices for curtailment."""
+        # TODO
+        client = EntsoePandasClient(api_key=api_key)
+        country_code = "NL"  # Netherlands
+        start = self.now
+        end = self.now + pd.Timedelta(days=2)  # fetch a week of data
+
+        # methods that return Pandas Series
+        log.info(f"Fetching day-ahead prices from ENTSOE API for {country_code} \
+                 from {start} to {end}")
+        data = client.query_day_ahead_prices(country_code, start=start, end=end)
+
+        # validate data
+        if data.empty:
+            log.warning("No data returned from ENTSOE API.")
+            return pd.DataFrame()
+
+        # check there are not nans
+        if data.isnull().values.any():
+            log.warning("Data contains NaNs.")
+            return pd.DataFrame()
+
+        # make sure timezone is utc
+        data.index = data.index.tz_convert("UTC")
+
+        # convert to dataframe with columns ['target_datetime_utc', 'price']
+        data = data.reset_index()
+        data.columns = ["target_datetime_utc", "NL_day_ahead_prices_euros_per_mwh"]
+        data["target_datetime_utc"] = pd.to_datetime(data["target_datetime_utc"])
+
+        self.prices_df = data
+
+    def apply_curtailment(self, forecast_values: list[dict]) -> list[dict]:
+        """Apply curtailment to the forecast values.
+
+        This is v1 curtailment for NL.
+        If the prices are negative, then we reduce the values by 11%.
+        """
+        # make into dataframe and merge with prices
+        forecast_values_df = pd.DataFrame(forecast_values)
+        forecast_values_df = forecast_values_df.merge(
+            self.prices_df, on="target_datetime_utc", how="left",
+        )
+
+        # apply curtailment
+        forecast_values_df["curtailed"] = forecast_values_df[
+            "NL_day_ahead_prices_euros_per_mwh"
+        ].apply(lambda x: x < 0)
+        forecast_values_df["forecast_value"] = forecast_values_df.apply(
+            lambda row: row["forecast_value"] / 1.11 if row["curtailed"] else row["forecast_value"],
+            axis=1,
+        )
+
+        # convert back
+        return forecast_values_df.to_dict("records")

--- a/site_forecast_app/curtailment.py
+++ b/site_forecast_app/curtailment.py
@@ -51,12 +51,15 @@ class Curtailment:
 
         self.prices_df = data
 
-    def apply_curtailment(self, forecast_values: list[dict]) -> list[dict]:
+    def apply_curtailment(self, forecast_values: dict) -> dict:
         """Apply curtailment to the forecast values.
 
         This is v1 curtailment for NL.
         If the prices are negative, then we reduce the values by 11%.
         """
+        if len(forecast_values):
+            return forecast_values
+
         # make into dataframe and merge with prices
         forecast_values_df = pd.DataFrame(forecast_values)
         forecast_values_df = forecast_values_df.merge(

--- a/site_forecast_app/curtailment.py
+++ b/site_forecast_app/curtailment.py
@@ -23,7 +23,10 @@ class Curtailment:
         client = EntsoePandasClient(api_key=api_key)
         country_code = "NL"  # Netherlands
         start = self.now
-        end = self.now + pd.Timedelta(days=2)  # fetch a week of data
+        # make sure start has a timezone
+        if start.tzinfo is None:
+            start = start.tz_localize("UTC")
+        end = start + pd.Timedelta(days=2)  # fetch a week of data
 
         # methods that return Pandas Series
         log.info(f"Fetching day-ahead prices from ENTSOE API for {country_code} \

--- a/site_forecast_app/curtailment.py
+++ b/site_forecast_app/curtailment.py
@@ -72,7 +72,8 @@ class Curtailment:
             "NL_day_ahead_prices_euros_per_mwh"
         ].apply(lambda x: x < 0)
         forecast_values_df["forecast_power_kw"] = forecast_values_df.apply(
-            lambda row: row["forecast_power_kw"] / 1.11 if row["curtailed"] else row["forecast_power_kw"],
+            lambda row: row["forecast_power_kw"] / 1.11 if row["curtailed"] \
+                else row["forecast_power_kw"],
             axis=1,
         )
 

--- a/site_forecast_app/curtailment.py
+++ b/site_forecast_app/curtailment.py
@@ -55,7 +55,8 @@ class Curtailment:
         """Apply curtailment to the forecast values.
 
         This is v1 curtailment for NL.
-        If the prices are negative, then we reduce the values by 11%.
+        If the prices are negative, then we reduce the values by 9.1%.
+        (This is done by divided by 1.11 - this is what the analysis showed)
         """
         # for forecast values is None, then also return None
         if forecast_values is None:
@@ -71,6 +72,7 @@ class Curtailment:
         )
 
         # apply curtailment
+        # method as of 2026-05-15 from NedNL analysis
         forecast_values_df["curtailed"] = forecast_values_df[
             "NL_day_ahead_prices_euros_per_mwh"
         ].apply(lambda x: x < 0)

--- a/site_forecast_app/models/all_models.yaml
+++ b/site_forecast_app/models/all_models.yaml
@@ -19,6 +19,7 @@ models:
     asset_type: pv
     satellite_scaling_method: constant
     location_type: nation
+    curtailment: true
   - name: nl_regional_pv_ecmwf_sat
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -31,6 +32,7 @@ models:
     site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
     location_type: state
     summation_location_type: nation
+    curtailment: true
   - name: nl_regional_48h_pv_ecmwf
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -43,6 +45,7 @@ models:
     site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
     location_type: state
     summation_location_type: nation
+    curtailment: true
   - name: nl_regional_2h_pv_ecmwf
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -55,6 +58,7 @@ models:
     site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
     location_type: state
     summation_location_type: nation
+    curtailment: true
   - name: nl_regional_pv_ecmwf_mo_sat
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -67,6 +71,7 @@ models:
     site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
     location_type: state
     summation_location_type: nation
+    curtailment: true
     # India models below
   - name: pvnet_ad_sites_satellite_ecmwf_long_site_history
     type: pvnet

--- a/site_forecast_app/models/all_models.yaml
+++ b/site_forecast_app/models/all_models.yaml
@@ -10,7 +10,9 @@ models:
     asset_type: pv
     satellite_scaling_method: constant
     location_type: nation
+    # the generation data that is loaded
     observer_name: nednl_no_curtailment
+    # the generation data used for the adjuster
     observer_name_adjuster: nednl
   - name: nl_national_pv_ecmwf_sat_small
     type: pvnet
@@ -22,7 +24,9 @@ models:
     satellite_scaling_method: constant
     location_type: nation
     curtailment: true
+    # the generation data that is loaded
     observer_name: nednl_no_curtailment
+    # the generation data used for the adjuster
     observer_name_adjuster: nednl
   - name: nl_regional_pv_ecmwf_sat
     type: pvnet
@@ -37,7 +41,9 @@ models:
     location_type: state
     summation_location_type: nation
     curtailment: true
+    # the generation data that is loaded
     observer_name: nednl_no_curtailment
+    # the generation data used for the adjuster
     observer_name_adjuster: nednl
   - name: nl_regional_48h_pv_ecmwf
     type: pvnet
@@ -52,7 +58,9 @@ models:
     location_type: state
     summation_location_type: nation
     curtailment: true
-    observer_name: nednl_no_curtailment
+    # the generation data that is loaded
+    observer_name: nednl_no_curtailment 
+    # the generation data used for the adjuster
     observer_name_adjuster: nednl
   - name: nl_regional_2h_pv_ecmwf
     type: pvnet
@@ -67,7 +75,9 @@ models:
     location_type: state
     summation_location_type: nation
     curtailment: true
+    # the generation data that is loaded
     observer_name: nednl_no_curtailment
+    # the generation data used for the adjuster
     observer_name_adjuster: nednl
   - name: nl_regional_pv_ecmwf_mo_sat
     type: pvnet
@@ -82,7 +92,9 @@ models:
     location_type: state
     summation_location_type: nation
     curtailment: true
+    # the generation data that is loaded
     observer_name: nednl_no_curtailment
+    # the generation data used for the adjuster
     observer_name_adjuster: nednl
     # Uncurtailed model below
   - name: nl_regional_ecmwf_mo_sat
@@ -97,7 +109,9 @@ models:
     site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
     location_type: state
     summation_location_type: nation
+    # the generation data that is loaded
     observer_name: nednl_no_curtailment
+    # the generation data used for the adjuster
     observer_name_adjuster: nednl_no_curtailment
     # India models below
   - name: pvnet_ad_sites_satellite_ecmwf_long_site_history

--- a/site_forecast_app/models/all_models.yaml
+++ b/site_forecast_app/models/all_models.yaml
@@ -10,7 +10,8 @@ models:
     asset_type: pv
     satellite_scaling_method: constant
     location_type: nation
-    observer_name: nednl
+    observer_name: nednl_no_curtailment
+    observer_name_adjuster: nednl
   - name: nl_national_pv_ecmwf_sat_small
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -21,7 +22,8 @@ models:
     satellite_scaling_method: constant
     location_type: nation
     curtailment: true
-    observer_name: nednl
+    observer_name: nednl_no_curtailment
+    observer_name_adjuster: nednl
   - name: nl_regional_pv_ecmwf_sat
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -35,7 +37,8 @@ models:
     location_type: state
     summation_location_type: nation
     curtailment: true
-    observer_name: nednl
+    observer_name: nednl_no_curtailment
+    observer_name_adjuster: nednl
   - name: nl_regional_48h_pv_ecmwf
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -49,7 +52,8 @@ models:
     location_type: state
     summation_location_type: nation
     curtailment: true
-    observer_name: nednl
+    observer_name: nednl_no_curtailment
+    observer_name_adjuster: nednl
   - name: nl_regional_2h_pv_ecmwf
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -63,7 +67,8 @@ models:
     location_type: state
     summation_location_type: nation
     curtailment: true
-    observer_name: nednl
+    observer_name: nednl_no_curtailment
+    observer_name_adjuster: nednl
   - name: nl_regional_pv_ecmwf_mo_sat
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -77,7 +82,8 @@ models:
     location_type: state
     summation_location_type: nation
     curtailment: true
-    observer_name: nednl
+    observer_name: nednl_no_curtailment
+    observer_name_adjuster: nednl
 
     # India models below
   - name: pvnet_ad_sites_satellite_ecmwf_long_site_history

--- a/site_forecast_app/models/pvnet/model.py
+++ b/site_forecast_app/models/pvnet/model.py
@@ -321,6 +321,10 @@ class PVNetModel:
             values_df,
         )
 
+        # format target_datetime_utc
+        values_df["target_datetime_utc"] = values_df["start_utc"]
+        values_df["target_datetime_utc"] = values_df["target_datetime_utc"].dt.tz_localize("UTC")
+
         return values_df.to_dict("records")
 
     def _prepare_data_sources(self) -> None:

--- a/site_forecast_app/models/pvnet/model.py
+++ b/site_forecast_app/models/pvnet/model.py
@@ -322,8 +322,7 @@ class PVNetModel:
         )
 
         # format target_datetime_utc
-        values_df["target_datetime_utc"] = values_df["start_utc"]
-        values_df["target_datetime_utc"] = values_df["target_datetime_utc"].dt.tz_localize("UTC")
+        values_df["target_datetime_utc"] = values_df["start_utc"].dt.tz_localize("UTC")
 
         return values_df.to_dict("records")
 

--- a/site_forecast_app/models/pydantic_models.py
+++ b/site_forecast_app/models/pydantic_models.py
@@ -78,6 +78,12 @@ class Model(BaseModel):
         description="The type of location for the summation outcome (site, state, or nation)",
     )
 
+    curtailment: bool = Field(
+        False,
+        title="Curtailment",
+        description="Whether the model should apply curtailment to the forecasts.",
+    )
+
 
 class Models(BaseModel):
     """A group of ml models."""

--- a/site_forecast_app/models/pydantic_models.py
+++ b/site_forecast_app/models/pydantic_models.py
@@ -83,11 +83,17 @@ class Model(BaseModel):
         title="Curtailment",
         description="Whether the model should apply curtailment to the forecasts.",
     )
-    
+
     observer_name: str | None = Field(
         None,
         title="Observer Name",
         description="The name of the observer to fetch DP generation data from",
+    )
+
+    observer_name_adjuster: str | None = Field(
+        None,
+        title="Observer Name for the adjuster",
+        description="The name of the observer to fetch DP use for the adjuster",
     )
 
 

--- a/site_forecast_app/save/data_platform.py
+++ b/site_forecast_app/save/data_platform.py
@@ -82,6 +82,7 @@ async def save_to_dataplatform(
     ml_model_name: str | None,
     location_map: dict[str, str] | None = None,
     use_adjuster: bool = True,
+    observer_name: str | None = None,
 ) -> None:
     """Save Forecast to Dataplatform."""
     client_location_name = forecast_meta.get("client_location_name")
@@ -111,6 +112,7 @@ async def save_to_dataplatform(
                 location_type=forecast_meta.get("location_type", dp.LocationType.SITE),
                 location_map=location_map,
                 use_adjuster=use_adjuster,
+                observer_name=observer_name,
             )
         log.info(f"Save complete for location={client_location_name!r}")
     except Exception as e:
@@ -125,6 +127,7 @@ async def make_forecaster_adjuster(
     forecast_values: list[dp.CreateForecastRequestForecastValue],
     model_tag: str,
     forecaster: dp.Forecaster,
+    observer_name: str | None = None,
 ) -> dp.CreateForecastRequest:
     """Build an adjusted forecast request using week-average deltas from the Data Platform.
 
@@ -139,16 +142,21 @@ async def make_forecaster_adjuster(
         forecast_values: Base forecast values to adjust.
         model_tag: Model name used to look up/create the adjuster forecaster.
         forecaster: The base forecaster object (used to fetch deltas).
+        observer_name: The name of the observer to use for the adjuster
+            (defaults to env var OBSERVER_NAME or "nednl").
 
     Returns:
         A ``CreateForecastRequest`` for the adjusted forecast.
     """
+    if observer_name is None:
+        observer_name = os.getenv("OBSERVER_NAME", "nednl")
+
     deltas_request = dp.GetWeekAverageDeltasRequest(
         location_uuid=location_uuid,
         energy_source=dp.EnergySource.SOLAR,
         pivot_timestamp_utc=init_time_utc.replace(tzinfo=UTC),
         forecaster=forecaster,
-        observer_name=os.getenv("OBSERVER_NAME", "nednl"),
+        observer_name=observer_name,
     )
     deltas_response = await client.get_week_average_deltas(deltas_request)
     deltas = deltas_response.deltas
@@ -382,6 +390,7 @@ async def save_forecast_to_dataplatform(
     location_type: dp.LocationType = dp.LocationType.SITE,
     location_map: dict[str, str] | None = None,
     use_adjuster: bool = True,
+    observer_name: str | None = None,
 ) -> None:
     """Save forecast to the Data Platform."""
     app_version = version("site-forecast-app")
@@ -485,6 +494,7 @@ async def save_forecast_to_dataplatform(
                 forecast_values=forecast_values,
                 model_tag=model_tag,
                 forecaster=forecaster,
+                observer_name=observer_name,
             )
             await client.create_forecast(adjusted_request)
             log.info(f"Adjusted forecast submitted for {client_location_name!r}")

--- a/site_forecast_app/save/save.py
+++ b/site_forecast_app/save/save.py
@@ -27,6 +27,7 @@ def save_forecast(
     use_adjuster_database: bool = True,
     adjuster_average_minutes: int | None = 60,
     location_map: dict[str, str] | None = None,
+    observer_name: str | None = None,
 ) -> None:
     """Save a forecast for a given site & timestamp.
 
@@ -41,6 +42,7 @@ def save_forecast(
         adjuster_average_minutes: Minutes to average over when calculating adjuster values
         location_map: Optional pre-fetched mapping of DP location name to UUID.
             When provided, avoids a list_locations gRPC call per site.
+        observer_name: The name of the observer to use for the adjuster
 
     Raises:
         IOError: An error if the database save fails
@@ -104,5 +106,6 @@ def save_forecast(
                 ml_model_name=ml_model_name,
                 location_map=location_map,
                 use_adjuster=ml_model_name is not None,
+                observer_name=observer_name,
             ),
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -634,3 +634,14 @@ def use_satellite():
 def blend_config() -> BlendConfig:
     """Fixture providing a real BlendConfig populated from config.yaml."""
     return load_blend_config(client_name="nl")
+
+@pytest.fixture
+def mock_da_prices() -> pd.DataFrame:
+    start = pd.Timestamp("2026-05-12").tz_localize("UTC")
+    end = pd.Timestamp("2026-05-13").tz_localize("UTC")
+    mock_da_prices = pd.DataFrame({
+        "target_datetime_utc": pd.date_range(start=start, end=end, freq="15min"),
+        "price": [10] * (4*24+1),   # 1 days +1
+    })
+    mock_da_prices.set_index("target_datetime_utc", inplace=True)
+    return mock_da_prices

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,6 +7,7 @@ import json
 import multiprocessing as mp
 import os
 import uuid
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -157,8 +158,10 @@ def test_save_forecast(db_session, sites, forecast_values):
 
 
 @freeze_time(now)
+@patch("site_forecast_app.curtailment.EntsoePandasClient")
 @pytest.mark.parametrize("write_to_db", [True, False])
 def test_app(
+    mock_entsoe_pandas_client,
     write_to_db,
     db_session,
     sites,  # noqa: ARG001
@@ -166,10 +169,15 @@ def test_app(
     nwp_mo_global_data_nl,  # noqa: ARG001
     generation_db_values,   # noqa: ARG001
     satellite_data,  # noqa: ARG001
+    mock_da_prices,
 ):
     """Test for running app from command line"""
     os.environ["CLIENT_NAME"] = "nl"
     os.environ["COUNTRY"] = "nl"
+
+    mock_entsoe_pandas_client_instance = MagicMock()
+    mock_entsoe_pandas_client.return_value = mock_entsoe_pandas_client_instance
+    mock_entsoe_pandas_client_instance.query_day_ahead_prices.return_value = mock_da_prices
 
     init_n_forecasts = db_session.query(ForecastSQL).count()
     init_n_forecast_values = db_session.query(ForecastValueSQL).count()

--- a/tests/unit/test_curtailment.py
+++ b/tests/unit/test_curtailment.py
@@ -6,42 +6,35 @@ from site_forecast_app.curtailment import Curtailment
 
 
 @patch("site_forecast_app.curtailment.EntsoePandasClient")
-def test_get_entsoe_day_prices(mock_entsoe_pandas_client):
+def test_get_entsoe_day_prices(mock_entsoe_pandas_client, mock_da_prices):
 
-    start = pd.Timestamp("2026-05-12").tz_localize("UTC")
-    end = pd.Timestamp("2026-05-14").tz_localize("UTC")
-
-    mock_da_prices = pd.DataFrame({
-        "target_datetime_utc": pd.date_range(start=start, end=end, freq="15min"),
-        "price": [10] * (4*24*2+1),   # 2 days +1
-    })
-    mock_da_prices.set_index("target_datetime_utc", inplace=True)
     mock_entsoe_pandas_client_instance = MagicMock()
     mock_entsoe_pandas_client.return_value = mock_entsoe_pandas_client_instance
     mock_entsoe_pandas_client_instance.query_day_ahead_prices.return_value = mock_da_prices
 
-    prices = Curtailment(now=start).prices_df
+    prices = Curtailment(now=mock_da_prices.index.min()).prices_df
     assert prices is not None
     assert isinstance(prices, pd.DataFrame)
     assert not prices.empty
-    assert len(prices) == 4*24*2+1 # 15 minute intervals in one day + 1
+    assert len(prices) == 4*24+1 # 15 minute intervals in one day + 1
 
 
 @patch("site_forecast_app.curtailment.EntsoePandasClient")
-def test_make_potential_generation(mock_entsoe_pandas_client):
-    start = pd.Timestamp("2026-05-10").tz_localize("UTC")
-    end = pd.Timestamp("2026-05-11").tz_localize("UTC")
+def test_make_potential_generation(mock_entsoe_pandas_client, mock_da_prices):
+    start = pd.Timestamp("2026-05-12").tz_localize("UTC")
+    end = pd.Timestamp("2026-05-13").tz_localize("UTC")
 
     data = pd.DataFrame({
         "target_datetime_utc": pd.date_range(start=start, end=end, freq="15min"),
         "forecast_value": [1] * 97,
     })
 
-    mock_da_prices = pd.DataFrame({
-        "target_datetime_utc": pd.date_range(start=start, end=end, freq="15min"),
-        "price": [10] * 33 + [-1] * 25 + [1]* 39,
-    })
-    mock_da_prices.set_index("target_datetime_utc", inplace=True)
+    # add negative prices
+    negative_prices_idx =\
+          (mock_da_prices.index.time >= pd.Timestamp("08:15").time()) \
+        & (mock_da_prices.index.time <= pd.Timestamp("14:15").time())
+    mock_da_prices.loc[negative_prices_idx, "price"] = -1
+
     mock_entsoe_pandas_client_instance = MagicMock()
     mock_entsoe_pandas_client.return_value = mock_entsoe_pandas_client_instance
     mock_entsoe_pandas_client_instance.query_day_ahead_prices.return_value = mock_da_prices

--- a/tests/unit/test_curtailment.py
+++ b/tests/unit/test_curtailment.py
@@ -1,0 +1,65 @@
+from unittest.mock import patch, Mock
+import numpy as np
+import pandas as pd
+from unittest.mock import MagicMock
+from site_forecast_app.curtailment import Curtailment
+
+
+@patch("site_forecast_app.curtailment.EntsoePandasClient")
+def test_get_entsoe_day_prices(mock_entsoe_pandas_client):
+
+    start = pd.Timestamp('2026-05-12').tz_localize('UTC')
+    end = pd.Timestamp('2026-05-14').tz_localize('UTC')
+
+    mock_da_prices = pd.DataFrame({
+        'target_datetime_utc': pd.date_range(start=start, end=end, freq='15min'),
+        'price': [10] * (4*24*2+1)   # 2 days +1
+    })
+    mock_da_prices.set_index('target_datetime_utc', inplace=True)
+    mock_entsoe_pandas_client_instance = MagicMock()
+    mock_entsoe_pandas_client.return_value = mock_entsoe_pandas_client_instance
+    mock_entsoe_pandas_client_instance.query_day_ahead_prices.return_value = mock_da_prices
+
+    prices = Curtailment(now=start).prices_df
+    assert prices is not None
+    assert isinstance(prices, pd.DataFrame)
+    assert not prices.empty
+    assert len(prices) == 4*24*2+1 # 15 minute intervals in one day + 1
+
+
+@patch("site_forecast_app.curtailment.EntsoePandasClient")
+def test_make_potential_generation(mock_entsoe_pandas_client):
+    start = pd.Timestamp('2026-05-10').tz_localize('UTC')
+    end = pd.Timestamp('2026-05-11').tz_localize('UTC')
+
+    data = pd.DataFrame({
+        'target_datetime_utc': pd.date_range(start=start, end=end, freq='15min'),
+        'forecast_value': [1] * 97
+    })
+
+    mock_da_prices = pd.DataFrame({
+        'target_datetime_utc': pd.date_range(start=start, end=end, freq='15min'),
+        'price': [10] * 33 + [-1] * 25 + [1]* 39
+    })
+    mock_da_prices.set_index('target_datetime_utc', inplace=True)
+    mock_entsoe_pandas_client_instance = MagicMock()
+    mock_entsoe_pandas_client.return_value = mock_entsoe_pandas_client_instance
+    mock_entsoe_pandas_client_instance.query_day_ahead_prices.return_value = mock_da_prices
+
+    curtailment = Curtailment(now=start)
+    potential_generation = curtailment.apply_curtailment(forecast_values=data.to_dict(orient='records'))
+    potential_generation = pd.DataFrame(potential_generation)
+    assert potential_generation is not None
+    assert isinstance(potential_generation, pd.DataFrame)
+    assert not potential_generation.empty
+    assert len(potential_generation) == 97 # 15 minute intervals in one day + 1
+    assert potential_generation.iloc[0].forecast_value == 1 # 00:00 is 1
+    assert potential_generation.iloc[48].forecast_value == 1/1.11 #12:00 has been increased
+
+    # we know that the prices at 8:15 to 14:15 was negative
+    # lets check these values
+    negative_prices_idx = (potential_generation['target_datetime_utc'].dt.time >= pd.Timestamp('08:15').time()) \
+        & (data['target_datetime_utc'].dt.time <= pd.Timestamp('14:15').time())
+    # check the negative prices are all zero
+    assert (potential_generation.loc[negative_prices_idx, "forecast_value"]== 1/1.11).all()
+    assert (potential_generation.loc[~negative_prices_idx, "forecast_value"]== 1).all()

--- a/tests/unit/test_curtailment.py
+++ b/tests/unit/test_curtailment.py
@@ -26,7 +26,7 @@ def test_make_potential_generation(mock_entsoe_pandas_client, mock_da_prices):
 
     data = pd.DataFrame({
         "target_datetime_utc": pd.date_range(start=start, end=end, freq="15min"),
-        "forecast_value": [1] * 97,
+        "forecast_power_kw": [1] * 97,
     })
 
     # add negative prices
@@ -40,15 +40,15 @@ def test_make_potential_generation(mock_entsoe_pandas_client, mock_da_prices):
     mock_entsoe_pandas_client_instance.query_day_ahead_prices.return_value = mock_da_prices
 
     curtailment = Curtailment(now=start)
-    forecast_values = data.to_dict(orient="records")
+    forecast_values = data.to_dict("records")
     potential_generation = curtailment.apply_curtailment(forecast_values=forecast_values)
     potential_generation = pd.DataFrame(potential_generation)
     assert potential_generation is not None
     assert isinstance(potential_generation, pd.DataFrame)
     assert not potential_generation.empty
     assert len(potential_generation) == 97 # 15 minute intervals in one day + 1
-    assert potential_generation.iloc[0].forecast_value == 1 # 00:00 is 1
-    assert potential_generation.iloc[48].forecast_value == 1/1.11 #12:00 has been increased
+    assert potential_generation.iloc[0].forecast_power_kw == 1 # 00:00 is 1
+    assert potential_generation.iloc[48].forecast_power_kw == 1/1.11 #12:00 has been increased
 
     # we know that the prices at 8:15 to 14:15 was negative
     # lets check these values
@@ -56,5 +56,5 @@ def test_make_potential_generation(mock_entsoe_pandas_client, mock_da_prices):
           (potential_generation["target_datetime_utc"].dt.time >= pd.Timestamp("08:15").time()) \
         & (data["target_datetime_utc"].dt.time <= pd.Timestamp("14:15").time())
     # check the negative prices are all zero
-    assert (potential_generation.loc[negative_prices_idx, "forecast_value"]== 1/1.11).all()
-    assert (potential_generation.loc[~negative_prices_idx, "forecast_value"]== 1).all()
+    assert (potential_generation.loc[negative_prices_idx, "forecast_power_kw"]== 1/1.11).all()
+    assert (potential_generation.loc[~negative_prices_idx, "forecast_power_kw"]== 1).all()

--- a/tests/unit/test_curtailment.py
+++ b/tests/unit/test_curtailment.py
@@ -1,21 +1,21 @@
-from unittest.mock import patch, Mock
-import numpy as np
+from unittest.mock import MagicMock, patch
+
 import pandas as pd
-from unittest.mock import MagicMock
+
 from site_forecast_app.curtailment import Curtailment
 
 
 @patch("site_forecast_app.curtailment.EntsoePandasClient")
 def test_get_entsoe_day_prices(mock_entsoe_pandas_client):
 
-    start = pd.Timestamp('2026-05-12').tz_localize('UTC')
-    end = pd.Timestamp('2026-05-14').tz_localize('UTC')
+    start = pd.Timestamp("2026-05-12").tz_localize("UTC")
+    end = pd.Timestamp("2026-05-14").tz_localize("UTC")
 
     mock_da_prices = pd.DataFrame({
-        'target_datetime_utc': pd.date_range(start=start, end=end, freq='15min'),
-        'price': [10] * (4*24*2+1)   # 2 days +1
+        "target_datetime_utc": pd.date_range(start=start, end=end, freq="15min"),
+        "price": [10] * (4*24*2+1),   # 2 days +1
     })
-    mock_da_prices.set_index('target_datetime_utc', inplace=True)
+    mock_da_prices.set_index("target_datetime_utc", inplace=True)
     mock_entsoe_pandas_client_instance = MagicMock()
     mock_entsoe_pandas_client.return_value = mock_entsoe_pandas_client_instance
     mock_entsoe_pandas_client_instance.query_day_ahead_prices.return_value = mock_da_prices
@@ -29,25 +29,26 @@ def test_get_entsoe_day_prices(mock_entsoe_pandas_client):
 
 @patch("site_forecast_app.curtailment.EntsoePandasClient")
 def test_make_potential_generation(mock_entsoe_pandas_client):
-    start = pd.Timestamp('2026-05-10').tz_localize('UTC')
-    end = pd.Timestamp('2026-05-11').tz_localize('UTC')
+    start = pd.Timestamp("2026-05-10").tz_localize("UTC")
+    end = pd.Timestamp("2026-05-11").tz_localize("UTC")
 
     data = pd.DataFrame({
-        'target_datetime_utc': pd.date_range(start=start, end=end, freq='15min'),
-        'forecast_value': [1] * 97
+        "target_datetime_utc": pd.date_range(start=start, end=end, freq="15min"),
+        "forecast_value": [1] * 97,
     })
 
     mock_da_prices = pd.DataFrame({
-        'target_datetime_utc': pd.date_range(start=start, end=end, freq='15min'),
-        'price': [10] * 33 + [-1] * 25 + [1]* 39
+        "target_datetime_utc": pd.date_range(start=start, end=end, freq="15min"),
+        "price": [10] * 33 + [-1] * 25 + [1]* 39,
     })
-    mock_da_prices.set_index('target_datetime_utc', inplace=True)
+    mock_da_prices.set_index("target_datetime_utc", inplace=True)
     mock_entsoe_pandas_client_instance = MagicMock()
     mock_entsoe_pandas_client.return_value = mock_entsoe_pandas_client_instance
     mock_entsoe_pandas_client_instance.query_day_ahead_prices.return_value = mock_da_prices
 
     curtailment = Curtailment(now=start)
-    potential_generation = curtailment.apply_curtailment(forecast_values=data.to_dict(orient='records'))
+    forecast_values = data.to_dict(orient="records")
+    potential_generation = curtailment.apply_curtailment(forecast_values=forecast_values)
     potential_generation = pd.DataFrame(potential_generation)
     assert potential_generation is not None
     assert isinstance(potential_generation, pd.DataFrame)
@@ -58,8 +59,9 @@ def test_make_potential_generation(mock_entsoe_pandas_client):
 
     # we know that the prices at 8:15 to 14:15 was negative
     # lets check these values
-    negative_prices_idx = (potential_generation['target_datetime_utc'].dt.time >= pd.Timestamp('08:15').time()) \
-        & (data['target_datetime_utc'].dt.time <= pd.Timestamp('14:15').time())
+    negative_prices_idx =\
+          (potential_generation["target_datetime_utc"].dt.time >= pd.Timestamp("08:15").time()) \
+        & (data["target_datetime_utc"].dt.time <= pd.Timestamp("14:15").time())
     # check the negative prices are all zero
     assert (potential_generation.loc[negative_prices_idx, "forecast_value"]== 1/1.11).all()
     assert (potential_generation.loc[~negative_prices_idx, "forecast_value"]== 1).all()

--- a/uv.lock
+++ b/uv.lock
@@ -127,6 +127,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "betterproto"
 version = "2.0.0b7"
 source = { registry = "https://pypi.org/simple" }
@@ -474,6 +487,21 @@ wheels = [
 ]
 
 [[package]]
+name = "entsoe-py"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "pandas" },
+    { name = "pytz" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/e0/32901b9f168e84ffad3cda9df2412c3367f3ba96c6f78f58fdd72a8414bf/entsoe_py-0.8.0.tar.gz", hash = "sha256:afb012ff62594191f377c468c15f67769c7762b08d543e042ba05120b4832b22", size = 1599546, upload-time = "2026-04-14T21:24:34.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/dd/75082aceaec9d51825b1a6f5c2dc0d28d1b331a9194a0d94c9f10c9323aa/entsoe_py-0.8.0-py3-none-any.whl", hash = "sha256:64f17ce478a1563d26a24f2ba4bc91cd2501e8aeedb1cc9ef320dc20e8daf2e8", size = 1621292, upload-time = "2026-04-14T21:24:32.533Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -716,6 +744,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/e8/2e1462c8fdbe0f210feb5ac7ad2d9029af8be3bf45bd9fa39765f821642f/greenlet-3.3.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5fd23b9bc6d37b563211c6abbb1b3cab27db385a4449af5c32e932f93017080c", size = 274974, upload-time = "2026-01-23T15:31:02.891Z" },
     { url = "https://files.pythonhosted.org/packages/7e/a8/530a401419a6b302af59f67aaf0b9ba1015855ea7e56c036b5928793c5bd/greenlet-3.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09f51496a0bfbaa9d74d36a52d2580d1ef5ed4fdfcff0a73730abfbbbe1403dd", size = 577175, upload-time = "2026-01-23T16:00:56.213Z" },
     { url = "https://files.pythonhosted.org/packages/8e/89/7e812bb9c05e1aaef9b597ac1d0962b9021d2c6269354966451e885c4e6b/greenlet-3.3.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb0feb07fe6e6a74615ee62a880007d976cf739b6669cce95daa7373d4fc69c5", size = 590401, upload-time = "2026-01-23T16:05:26.365Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ae/e2d5f0e59b94a2269b68a629173263fa40b63da32f5c231307c349315871/greenlet-3.3.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:67ea3fc73c8cd92f42467a72b75e8f05ed51a0e9b1d15398c913416f2dafd49f", size = 601161, upload-time = "2026-01-23T16:15:53.456Z" },
     { url = "https://files.pythonhosted.org/packages/5c/ae/8d472e1f5ac5efe55c563f3eabb38c98a44b832602e12910750a7c025802/greenlet-3.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39eda9ba259cc9801da05351eaa8576e9aa83eb9411e8f0c299e05d712a210f2", size = 590272, upload-time = "2026-01-23T15:32:49.411Z" },
     { url = "https://files.pythonhosted.org/packages/a8/51/0fde34bebfcadc833550717eade64e35ec8738e6b097d5d248274a01258b/greenlet-3.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2e7e882f83149f0a71ac822ebf156d902e7a5d22c9045e3e0d1daf59cee2cc9", size = 1550729, upload-time = "2026-01-23T16:04:20.867Z" },
     { url = "https://files.pythonhosted.org/packages/16/c9/2fb47bee83b25b119d5a35d580807bb8b92480a54b68fef009a02945629f/greenlet-3.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80aa4d79eb5564f2e0a6144fcc744b5a37c56c4a92d60920720e99210d88db0f", size = 1615552, upload-time = "2026-01-23T15:33:45.743Z" },
@@ -2064,6 +2093,7 @@ dependencies = [
     { name = "betterproto" },
     { name = "click" },
     { name = "dp-sdk" },
+    { name = "entsoe-py" },
     { name = "gcsfs" },
     { name = "grpclib" },
     { name = "huggingface-hub" },
@@ -2100,6 +2130,7 @@ requires-dist = [
     { name = "betterproto", specifier = ">=2.0.0b7" },
     { name = "click", specifier = "==8.1.7" },
     { name = "dp-sdk", url = "https://github.com/openclimatefix/data-platform/releases/download/v0.21.2/dp_sdk-0.21.2-py3-none-any.whl" },
+    { name = "entsoe-py", specifier = ">=0.8.0" },
     { name = "gcsfs", specifier = "==2025.10.0" },
     { name = "grpclib", specifier = ">=0.4.7" },
     { name = "huggingface-hub", specifier = "==0.20.3" },
@@ -2148,6 +2179,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull Request

## Description

- Have option to curtail the forecast. This is for NL.
- added config option where the generation data and adjuster observes can be different

So we have 
1. Load the no curtailed value from the adjuster
2. Run forecast
3. Curtail the forecast by 11% to reduce the forecast amount

https://github.com/openclimatefix/client-private/issues/432

## How Has This Been Tested?

- [x] CI tests
- [x] run locally
- [x] run locally when there is curtailment and see effect (curtailment on 2026-05-15)

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
