### PR TITLE
Uncurtailed model deployment

### DIFF
--- a/site_forecast_app/models/all_models.yaml
+++ b/site_forecast_app/models/all_models.yaml
@@ -10,6 +10,7 @@ models:
     asset_type: pv
     satellite_scaling_method: constant
     location_type: nation
+    observer_name: nednl
   - name: nl_national_pv_ecmwf_sat_small
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -19,6 +20,7 @@ models:
     asset_type: pv
     satellite_scaling_method: constant
     location_type: nation
+    observer_name: nednl
   - name: nl_regional_pv_ecmwf_sat
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -31,6 +33,7 @@ models:
     site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
     location_type: state
     summation_location_type: nation
+    observer_name: nednl
   - name: nl_regional_48h_pv_ecmwf
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -43,6 +46,7 @@ models:
     site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
     location_type: state
     summation_location_type: nation
+    observer_name: nednl
   - name: nl_regional_2h_pv_ecmwf
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -55,6 +59,7 @@ models:
     site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
     location_type: state
     summation_location_type: nation
+    observer_name: nednl
   - name: nl_regional_pv_ecmwf_mo_sat
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -67,6 +72,7 @@ models:
     site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
     location_type: state
     summation_location_type: nation
+    observer_name: nednl
     # Uncurtailed model below
   - name: nl_regional_ecmwf_mo_sat
     type: pvnet
@@ -80,6 +86,7 @@ models:
     site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
     location_type: state
     summation_location_type: nation
+    observer_name: nednl
     # India models below
   - name: pvnet_ad_sites_satellite_ecmwf_long_site_history
     type: pvnet

--- a/site_forecast_app/models/all_models.yaml
+++ b/site_forecast_app/models/all_models.yaml
@@ -67,6 +67,19 @@ models:
     site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
     location_type: state
     summation_location_type: nation
+    # Uncurtailed model below
+  - name: nl_regional_ecmwf_mo_sat
+    type: pvnet
+    id: openclimatefix-models/pvnet_nl
+    version: c5b25a74b99807645114a1b866a83adc7c270d2c
+    summation_id: openclimatefix-models/pvnet_nl
+    summation_version: 1be9cd5b4688aad9ffa738a2ba229990dc795a47
+    client: nl
+    asset_type: pv
+    satellite_scaling_method: constant
+    site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
+    location_type: state
+    summation_location_type: nation
     # India models below
   - name: pvnet_ad_sites_satellite_ecmwf_long_site_history
     type: pvnet

--- a/tests/models/test_pydantic_models.py
+++ b/tests/models/test_pydantic_models.py
@@ -6,7 +6,7 @@ from site_forecast_app.models.pydantic_models import Model, get_all_models
 def test_get_all_models():
     """Test for getting all models"""
     models = get_all_models()
-    assert len(models.models) == 13
+    assert len(models.models) == 14
 
 
 def test_site_group_uuid():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -183,7 +183,7 @@ def test_app(
 
     fv_per_hour = 4 # 15 min resolution = 4 values per hour
     n_forecasts = 6 + 12*4
-    n_models = 6
+    n_models = 7
     # 1 site, 5 models do 36 hours
     # 4 regional models also do 36 hours for 12 more sites
     # average number of forecast is:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -182,7 +182,7 @@ def test_app(
     assert result.exit_code == 0
 
     fv_per_hour = 4 # 15 min resolution = 4 values per hour
-    n_forecasts = 6 + 12*4
+    n_forecasts = 7 + 12*5
     n_models = 7
     # 1 site, 5 models do 36 hours
     # 4 regional models also do 36 hours for 12 more sites


### PR DESCRIPTION
New uncurtailed NL regional model (nl_regional_ecmwf_mo_sat) verified on dev data platform.

Screenshot below displays forecast for national.

For further clarity, model uses ECMWF, MO and sat inputs without PV.