### PR TITLE
only use adjuster on nl national

### DIFF
--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -305,7 +305,7 @@ def app_run(
                             ml_model_version=version,
                             location_map=dp_location_map,
                             use_adjuster_database=use_adjuster_database,
-                            use_adjuster=True is site.ml_id == 0,
+                            use_adjuster=site.ml_id == 0,
                         )
                     successful_runs += 1
 

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -305,7 +305,7 @@ def app_run(
                             ml_model_version=version,
                             location_map=dp_location_map,
                             use_adjuster_database=use_adjuster_database,
-                            use_adjuster=True is site.ml_id == 0
+                            use_adjuster=True is site.ml_id == 0,
                         )
                     successful_runs += 1
 

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -305,6 +305,7 @@ def app_run(
                             ml_model_version=version,
                             location_map=dp_location_map,
                             use_adjuster_database=use_adjuster_database,
+                            use_adjuster=True is site.ml_id == 0
                         )
                     successful_runs += 1
 

--- a/site_forecast_app/save/save.py
+++ b/site_forecast_app/save/save.py
@@ -28,6 +28,7 @@ def save_forecast(
     adjuster_average_minutes: int | None = 60,
     location_map: dict[str, str] | None = None,
     observer_name: str | None = None,
+    use_adjuster: bool = True
 ) -> None:
     """Save a forecast for a given site & timestamp.
 
@@ -43,6 +44,7 @@ def save_forecast(
         location_map: Optional pre-fetched mapping of DP location name to UUID.
             When provided, avoids a list_locations gRPC call per site.
         observer_name: The name of the observer to use for the adjuster
+        use_adjuster: Whether to save an extra model with the adjusted forecast
 
     Raises:
         IOError: An error if the database save fails
@@ -105,7 +107,7 @@ def save_forecast(
                 forecast_meta=forecast_meta,
                 ml_model_name=ml_model_name,
                 location_map=location_map,
-                use_adjuster=ml_model_name is not None,
+                use_adjuster=use_adjuster,
                 observer_name=observer_name,
             ),
         )

--- a/site_forecast_app/save/save.py
+++ b/site_forecast_app/save/save.py
@@ -28,7 +28,7 @@ def save_forecast(
     adjuster_average_minutes: int | None = 60,
     location_map: dict[str, str] | None = None,
     observer_name: str | None = None,
-    use_adjuster: bool = True
+    use_adjuster: bool = True,
 ) -> None:
     """Save a forecast for a given site & timestamp.
 


### PR DESCRIPTION
# Pull Request

## Description

Only save adjuster for ml_id=0. This is only for when a summation model is used, which is NL. For India adjuster is used. 

[Fixes #](https://github.com/openclimatefix/site-forecast-app/issues/174)

## How Has This Been Tested?

- [x] CI tests

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
