### PR TITLE
improve logging for failed runs

### DIFF
--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -271,7 +271,8 @@ def app_run(
                     log.info(
                         f"No forecast values for site_group_uuid={model_config.site_group_uuid}",
                     )
-                    failed_runs.append([model_config.name, model_config.site_group_uuid])
+                    failed_runs.append(f"model={model_config.name}, "
+                                       f"site_group_uuid={model_config.site_group_uuid}")
                 else:
 
                     if model_config.curtailment:
@@ -349,7 +350,9 @@ def app_run(
 
                     if forecast_values is None:
                         log.info(f"No forecast values for site_uuid={site_uuid}")
-                        failed_runs.append([model_config.name, site.client_location_name])
+                        failed_runs.append(
+                            f"model={model_config.name}, "
+                            f"site={site.client_location_name}")
                     else:
                         # 4. Write forecast to DB or stdout
                         log.info(f"Writing forecast for site_uuid={site_uuid}")

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -196,6 +196,7 @@ def app_run(
         all_model_configs = get_all_models(client_abbreviation=os.getenv("CLIENT_NAME", "nl"))
         successful_runs = 0
         runs = 0
+        failed_runs = []
 
         # Pre-fetch the DP location map once so _resolve_target_uuid doesn't call
         # list_locations on every individual forecast save.
@@ -270,6 +271,7 @@ def app_run(
                     log.info(
                         f"No forecast values for site_group_uuid={model_config.site_group_uuid}",
                     )
+                    failed_runs.append([model_config.name, model_config.site_group_uuid])
                 else:
 
                     if model_config.curtailment:
@@ -347,6 +349,7 @@ def app_run(
 
                     if forecast_values is None:
                         log.info(f"No forecast values for site_uuid={site_uuid}")
+                        failed_runs.append([model_config.name, site.client_location_name])
                     else:
                         # 4. Write forecast to DB or stdout
                         log.info(f"Writing forecast for site_uuid={site_uuid}")
@@ -393,7 +396,7 @@ def app_run(
         if successful_runs == runs:
             log.info("All forecasts completed successfully")
         elif 0 < successful_runs < runs:
-            raise Exception("Some forecasts failed")
+            raise Exception(f"Some forecasts failed {failed_runs}")
         else:
             raise Exception("All forecasts failed")
 


### PR DESCRIPTION
# Pull Request

## Description

This gives details of which forecasts have failed
#157 

## How Has This Been Tested?

 - [x] CI tests
 - [x] ran locally and with old 

```
Exception: Some forecasts failed ['model=nl_36_simple_site, site=nl_national', 'model=nl_national_pv_ecmwf_sat_small, site=nl_national', 'model=nl_regional_pv_ecmwf_sat, site_group_uuid=418259c9-0a31-4df7-a657-e53df9623897', 'model=nl_regional_pv_ecmwf_mo_sat, site_group_uuid=418259c9-0a31-4df7-a657-e53df9623897', 'model=nl_regional_ecmwf_mo_sat, site_group_uuid=418259c9-0a31-4df7-a657-e53df9623897']
```

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
