### PR TITLE
fix use values equal to 0 too

### DIFF
--- a/site_forecast_app/curtailment.py
+++ b/site_forecast_app/curtailment.py
@@ -75,7 +75,7 @@ class Curtailment:
         # method as of 2026-05-15 from NedNL analysis
         forecast_values_df["curtailed"] = forecast_values_df[
             "NL_day_ahead_prices_euros_per_mwh"
-        ].apply(lambda x: x < 0)
+        ].apply(lambda x: x <= 0)
         forecast_values_df["forecast_power_kw"] = forecast_values_df.apply(
             lambda row: row["forecast_power_kw"] / 1.11 if row["curtailed"] \
                 else row["forecast_power_kw"],


### PR DESCRIPTION
# Pull Request

## Description

Fix for curtailment, curtail when values are 0 and below (not just below)

## How Has This Been Tested?

- [x] CI tests
- [ ] ran on dev and saw curtailment effect

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
