### PR TITLE
Fail models when satellite data is too delayed

### DIFF
--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -22,8 +22,12 @@ from site_forecast_app.blend.app import run_blend_app
 from site_forecast_app.blend.config import load_blend_config
 from site_forecast_app.curtailment import Curtailment
 from site_forecast_app.data.generation import get_generation_data
+from site_forecast_app.data.satellite import (
+    check_model_satellite_inputs_available,
+    get_valid_satellite_times,
+)
 from site_forecast_app.models import PVNetModel, get_all_models
-from site_forecast_app.models.pvnet.consts import root_data_path
+from site_forecast_app.models.pvnet.consts import root_data_path, satellite_path
 from site_forecast_app.models.pydantic_models import Model
 from site_forecast_app.save import (
     build_dp_location_map,
@@ -257,6 +261,21 @@ def app_run(
 
                 log.info(f"{ml_model.site_uuid} model loaded")
 
+                # Validate satellite data is sufficient for this model's requirements.
+                # If not, skip to the next model rather than producing odd outputs.
+                if not check_model_satellite_inputs_available(
+                    data_config_filename=ml_model.populated_data_config_filename,
+                    t0=timestamp,
+                    sat_datetimes=get_valid_satellite_times(satellite_path),
+                ):
+                    log.warning(
+                        f"Skipping model {model_config.name} for site_group_uuid="
+                        f"{model_config.site_group_uuid}: satellite data is too delayed.",
+                    )
+                    failed_runs.append(f"model={model_config.name}, "
+                                       f"site_group_uuid={model_config.site_group_uuid}")
+                    continue
+
                 # 3. Run model for all sites
                 asset_type = model_config.asset_type
                 log.info(
@@ -339,6 +358,22 @@ def app_run(
                     )
 
                     log.info(f"{site} model loaded")
+
+                    # Validate satellite data is sufficient for this model's requirements.
+                    # The check result is the same for every site under this model_config,
+                    # so fail the model once and skip the remaining sites.
+                    if not check_model_satellite_inputs_available(
+                        data_config_filename=ml_model.populated_data_config_filename,
+                        t0=timestamp,
+                        sat_datetimes=get_valid_satellite_times(satellite_path),
+                    ):
+                        log.warning(
+                            f"Skipping model {model_config.name}: "
+                            "satellite data is too delayed.",
+                        )
+                        failed_runs.append(f"model={model_config.name}, "
+                                           f"site={site.client_location_name}")
+                        break
 
                     # 3. Run model for one site
                     asset_type = model_config.asset_type

--- a/site_forecast_app/data/satellite.py
+++ b/site_forecast_app/data/satellite.py
@@ -120,16 +120,6 @@ def download_satellite_data(satellite_source_file_path: str,
             times = ds.time.values
             log.info(f"Satellite data timestamps: {times}")
 
-        elif timedelta(minutes=0) < satellite_delay <= timedelta(minutes=30):
-            log.info("Satellite delay is 5 minuted or less. " \
-                     f"Appending a NaN timestamp at {latest_satellite_time+pd.Timedelta('5min')}")
-
-            # Extend the data with NaNs
-            ds = ds.reindex(time=np.concatenate([
-                ds.time,
-                [np.datetime64(latest_satellite_time + pd.Timedelta("5min"))],
-                ]), fill_value=np.nan)
-
         if scaling_method == "constant":
             log.info("Scaling satellite data to [0,1] range via constant scaling")
             # scale the dataset to 0-1

--- a/site_forecast_app/data/satellite.py
+++ b/site_forecast_app/data/satellite.py
@@ -10,6 +10,7 @@ import pandas as pd
 import xarray as xr
 import yaml
 import zarr
+from ocf_data_sampler.config.load import load_yaml_configuration
 
 log = logging.getLogger(__name__)
 
@@ -165,6 +166,86 @@ def download_satellite_data(satellite_source_file_path: str,
                               "x_geostationary": len(ds.x_geostationary)//4,
                               "variable": len(ds.variable)})
         ds.to_zarr(local_satellite_path, mode="a")
+
+
+def get_valid_satellite_times(satellite_zarr_path: str) -> pd.DatetimeIndex | None:
+    """Return the non-NaN satellite timestamps from a saved zarr.
+
+    The downloaded zarr may include a NaN-padded timestamp added for late data;
+    those are excluded so validation can detect when real satellite data does not
+    reach far enough toward t0. Returns None if the zarr does not exist.
+    """
+    if not os.path.exists(satellite_zarr_path):
+        return None
+    ds = xr.open_zarr(satellite_zarr_path)
+    nan_dims = [d for d in ds.data.dims if d != "time"]
+    valid_mask = ~ds.data.isnull().all(dim=nan_dims)
+    return pd.to_datetime(ds.time.values[valid_mask.values])
+
+
+def check_model_satellite_inputs_available(
+    data_config_filename: str,
+    t0: pd.Timestamp,
+    sat_datetimes: pd.DatetimeIndex | None,
+) -> bool:
+    """Checks whether the model can be run given the current satellite delay.
+
+    Args:
+        data_config_filename: Path to the data configuration file
+        t0: The init-time of the forecast
+        sat_datetimes: The available satellite timestamps
+
+    Returns:
+        bool: Whether the satellite data satisfies that specified in the config
+    """
+    input_config = load_yaml_configuration(data_config_filename).input_data
+
+    available = True
+
+    # Only check if using satellite data
+    model_uses_satellite = hasattr(input_config, "satellite") and (
+        input_config.satellite is not None
+    )
+
+    # In case the model does not require satellite
+    if not model_uses_satellite:
+        available = True
+
+    # In case the model requires satellite but none is available
+    elif model_uses_satellite and (sat_datetimes is None):
+        available = False
+
+    # In case the model requires satellite and some is available
+    elif model_uses_satellite:
+        # Take into account how recently the model tries to slice satellite data from
+        # interval_[start/end]_minutes is relative to t0 so negative means before t0
+        interval_start_minutes = input_config.satellite.interval_start_minutes
+        interval_end_minutes = input_config.satellite.interval_end_minutes
+
+        # Take into account the dropout the model was trained with
+        # If the model was trained with dropout, we can allow the satellite data to be
+        # delayed by most negative dropout time
+        if input_config.satellite.dropout_fraction > 0:
+            interval_end_minutes = min(
+                interval_end_minutes,
+                np.array(input_config.satellite.dropout_timedeltas_minutes).min(),
+            )
+
+        expected_datetimes = pd.date_range(
+            t0 + pd.Timedelta(f"{int(interval_start_minutes)}min"),
+            t0 + pd.Timedelta(f"{int(interval_end_minutes)}min"),
+            freq="5min",
+        )
+
+        # Check if any of the expected datetimes are missing
+        missing_time_steps = np.setdiff1d(expected_datetimes, sat_datetimes, assume_unique=True)
+
+        available = len(missing_time_steps) == 0
+
+        if len(missing_time_steps) > 0:
+            log.info(f"Some satellite timesteps for {t0=} missing: \n{missing_time_steps}")
+
+    return available
 
 
 def download_and_unzip(file_zip:str, file:str, temp_zarr_zip:str="sat_min.zarr.zip") -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,14 @@ log = logging.getLogger(__name__)
 
 random.seed(42)
 
+test_data_dir = os.path.dirname(os.path.abspath(__file__)) + "/test_data"
+
+
+@pytest.fixture(scope="session")
+def config_filename() -> str:
+    """Path to the test data config yaml."""
+    return f"{test_data_dir}/test.yaml"
+
 
 @pytest.fixture(scope="session")
 def engine():

--- a/tests/test_data/test.yaml
+++ b/tests/test_data/test.yaml
@@ -1,0 +1,27 @@
+general:
+  description: Test data config for site-forecast-app
+  name: test
+input_data:
+  satellite:
+    channels:
+    - IR_016
+    - VIS008
+    - WV_062
+    dropout_fraction: 0.0
+    dropout_timedeltas_minutes: []
+    image_size_pixels_height: 24
+    image_size_pixels_width: 24
+    interval_end_minutes: -30
+    interval_start_minutes: -60
+    normalisation_constants:
+      IR_016:
+        mean: 0.17594202
+        std: 0.21462157
+      VIS008:
+        mean: 0.11426069
+        std: 0.13090034
+      WV_062:
+        mean: 0.7359355
+        std: 0.16111417
+    time_resolution_minutes: 5
+    zarr_path: PLACEHOLDER.zarr

--- a/tests/unit/data/test_satellite.py
+++ b/tests/unit/data/test_satellite.py
@@ -1,10 +1,15 @@
 """ Tests for utils for pvnet"""
 import tempfile
 
+import pandas as pd
 import xarray as xr
 import zarr
 
-from site_forecast_app.data.satellite import download_satellite_data, satellite_scale_minmax
+from site_forecast_app.data.satellite import (
+    check_model_satellite_inputs_available,
+    download_satellite_data,
+    satellite_scale_minmax,
+)
 
 
 def test_satellite_scale_minmax(small_satellite_data,
@@ -57,3 +62,29 @@ def test_satellite_download_backup(small_satellite_data,
                                 satellite_backup_source_file_path=local_satellite_backup_path)
 
 
+def test_check_model_satellite_inputs_available(config_filename) -> None:
+    """Check satellite availability across full coverage, delay, and gap scenarios."""
+    t0 = pd.Timestamp("2023-01-01 00:00")
+    sat_datetime_1 = pd.date_range(
+        t0 - pd.Timedelta("120min"),
+        t0 - pd.Timedelta("5min"),
+        freq="5min",
+    )
+    sat_datetime_2 = pd.date_range(
+        t0 - pd.Timedelta("120min"),
+        t0 - pd.Timedelta("15min"),
+        freq="5min",
+    )
+    sat_datetime_3 = pd.date_range(
+        t0 - pd.Timedelta("120min"),
+        t0 - pd.Timedelta("35min"),
+        freq="5min",
+    )
+    sat_datetime_4 = pd.to_datetime([t for t in sat_datetime_1 if t != t0 - pd.Timedelta("30min")])
+    sat_datetime_5 = pd.to_datetime([t for t in sat_datetime_1 if t != t0 - pd.Timedelta("60min")])
+
+    assert check_model_satellite_inputs_available(config_filename, t0, sat_datetime_1)
+    assert check_model_satellite_inputs_available(config_filename, t0, sat_datetime_2)
+    assert not check_model_satellite_inputs_available(config_filename, t0, sat_datetime_3)
+    assert not check_model_satellite_inputs_available(config_filename, t0, sat_datetime_4)
+    assert not check_model_satellite_inputs_available(config_filename, t0, sat_datetime_5)


### PR DESCRIPTION
# Pull Request

## Description

- Added `check_model_satellite_inputs_available` (adapted from uk-pvnet-app) which compares the model's required satellite interval against the actually-available timestamps. When the satellite data does not reach the model's `interval_end_minutes` (e.g. a 5-min-delay model with 10-min late data), the model is skipped and added to failed_runs rather than producing odd results.

- Removed the padding for delay of 5 minutes

Fixes #185 

## How Has This Been Tested?

- [ ] with dev data-platform

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
