### PR TITLE
Improve curtailment nl

### DIFF
--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -297,7 +297,7 @@ def app_run(
                 # when not running the summation model, we get a list back,
                 # lets make sure its a dictionary like we get back if its a summation model
                 if isinstance(forecast_values, list):
-                    forecast_values = {0: forecast_values}
+                    forecast_values = {sites_for_model[0].ml_id: forecast_values}
 
                 if forecast_values is None:
                     log.info(

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -239,16 +239,20 @@ def app_run(
 
             if model_config.summation_version:
                 # Summation model provided, run the model concurrently on all sites
+                site_groups_for_running_model = [sites_for_model]
+                log.info("Running the model concurrently")
+            else:
+                site_groups_for_running_model = [[s] for s in sites_for_model]
+                log.info("Running the model for each site one by one")
+
+
+            for site_group in site_groups_for_running_model:
                 runs += 1
 
-                log.info("Running the model concurrently")
                 log.info("Reading latest historic generation data for all sites...")
                 generation_data = get_generation_data(
-                    session, sites_for_model, timestamp, observer_name=model_config.observer_name,
+                    session, site_group, timestamp, observer_name=model_config.observer_name,
                 )
-
-                log.debug(f"{generation_data['data']=}")
-                log.debug(f"{generation_data['metadata']=}")
 
                 log.info(f"Loading concurrent model {model_config.name}...")
                 ml_model = PVNetModel(
@@ -289,6 +293,11 @@ def app_run(
                     model=ml_model,
                     timestamp=timestamp,
                 )
+
+                # when not running the summation model, we get a list back,
+                # lets make sure its a dictionary like we get back if its a summation model
+                if isinstance(forecast_values, list):
+                    forecast_values = {0: forecast_values}
 
                 if forecast_values is None:
                     log.info(
@@ -334,91 +343,6 @@ def app_run(
                             use_adjuster=site.ml_id == 0,
                         )
                     successful_runs += 1
-
-            else:
-                # Summation model not provided, running model on one site at a time
-                for site in sites_for_model:
-                    runs += 1
-                    site_uuid = str(site.location_uuid)
-
-                    log.info(f"Reading latest historic {site} generation data...")
-                    generation_data = get_generation_data(
-                        session, [site], timestamp, observer_name=model_config.observer_name,
-                    )
-
-                    log.debug(f"{generation_data['data']=}")
-                    log.debug(f"{generation_data['metadata']=}")
-
-                    log.info(f"Loading {site} model {model_config.name}...")
-                    ml_model = PVNetModel(
-                        timestamp,
-                        generation_data,
-                        hf_repo=model_config.id,
-                        hf_version=model_config.version,
-                        name=model_config.name,
-                        satellite_scaling_method=model_config.satellite_scaling_method,
-                        site_uuid=site_uuid,
-                        asset_type=model_config.asset_type,
-                    )
-
-                    log.info(f"{site} model loaded")
-
-                    # Validate satellite data is sufficient for this model's requirements.
-                    # The check result is the same for every site under this model_config,
-                    # so fail the model once and skip the remaining sites.
-                    if not check_model_satellite_inputs_available(
-                        data_config_filename=ml_model.populated_data_config_filename,
-                        t0=timestamp,
-                        sat_datetimes=get_valid_satellite_times(satellite_path),
-                    ):
-                        log.warning(
-                            f"Skipping model {model_config.name}: "
-                            "satellite data is too delayed.",
-                        )
-                        failed_runs.append(f"model={model_config.name}, "
-                                           f"site={site.client_location_name}")
-                        break
-
-                    # 3. Run model for one site
-                    asset_type = model_config.asset_type
-                    log.info(f"Running {asset_type} model for site={site_uuid}...")
-                    forecast_values = run_model(
-                        model=ml_model,
-                        timestamp=timestamp,
-                    )
-
-                    if forecast_values is None:
-                        log.info(f"No forecast values for site_uuid={site_uuid}")
-                        failed_runs.append(
-                            f"model={model_config.name}, "
-                            f"site={site.client_location_name}")
-                    else:
-                        # 4. Write forecast to DB or stdout
-                        log.info(f"Writing forecast for site_uuid={site_uuid}")
-                        forecast = {
-                            "meta": {
-                                "location_uuid": site_uuid,
-                                "version": version,
-                                "timestamp": timestamp,
-                                "client_location_name": site.client_location_name,
-                                "capacity_kw": site.capacity_kw,
-                                "latitude": site.latitude,
-                                "longitude": site.longitude,
-                                "location_type": determine_location_type(site, model_config),
-                            },
-                            "values": forecast_values,
-                        }
-                        save_forecast(
-                            session,
-                            forecast=forecast,
-                            write_to_db=write_to_db,
-                            ml_model_name=ml_model.name,
-                            ml_model_version=version,
-                            location_map=dp_location_map,
-                            use_adjuster_database=use_adjuster_database,
-                            observer_name=model_config.observer_name_adjuster,
-                        )
-                        successful_runs += 1
 
         log.info(
             f"Completed forecasts for {successful_runs} runs for "

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -297,7 +297,7 @@ def app_run(
                 # when not running the summation model, we get a list back,
                 # lets make sure its a dictionary like we get back if its a summation model
                 if isinstance(forecast_values, list):
-                    forecast_values = {sites_for_model[0].ml_id: forecast_values}
+                    forecast_values = {site_group[0].ml_id: forecast_values}
 
                 if forecast_values is None:
                     log.info(

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -341,7 +341,7 @@ def app_run(
                             location_map=dp_location_map,
                             use_adjuster_database=use_adjuster_database,
                             use_adjuster=site.ml_id == 0,
-                            observer_name=model_config.model_config.observer_name_adjuster,
+                            observer_name=model_config.observer_name_adjuster,
                         )
                     successful_runs += 1
 

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -341,6 +341,7 @@ def app_run(
                             location_map=dp_location_map,
                             use_adjuster_database=use_adjuster_database,
                             use_adjuster=site.ml_id == 0,
+                            observer_name=model_config.model_config.observer_name_adjuster,
                         )
                     successful_runs += 1
 

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -312,7 +312,7 @@ def app_run(
                     log.info(
                         f"Writing forecast for site_group_uuid={model_config.site_group_uuid}",
                     )
-
+                    
                     save_forecast_for_site_group_partial = partial(save_forecast_for_site_group,
                         db_session=session,
                         # forecast_values=forecast_values,

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -312,7 +312,7 @@ def app_run(
                     log.info(
                         f"Writing forecast for site_group_uuid={model_config.site_group_uuid}",
                     )
-                    
+
                     save_forecast_for_site_group_partial = partial(save_forecast_for_site_group,
                         db_session=session,
                         # forecast_values=forecast_values,

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -298,7 +298,7 @@ def app_run(
                 # when not running the summation model, we get a list back,
                 # lets make sure its a dictionary like we get back if its a summation model
                 if isinstance(forecast_values, list):
-                    forecast_values = {sites_for_model[0].ml_id: forecast_values}
+                    forecast_values = {site_group[0].ml_id: forecast_values}
 
                 if forecast_values is None:
                     log.info(

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -313,9 +313,10 @@ def app_run(
                         f"Writing forecast for site_group_uuid={model_config.site_group_uuid}",
                     )
 
+                    # make a partial function for saving forecast, still need to set
+                    # forecast_values and model_name
                     save_forecast_for_site_group_partial = partial(save_forecast_for_site_group,
                         db_session=session,
-                        # forecast_values=forecast_values,
                         timestamp=timestamp,
                         site_group=site_group,
                         write_to_db=write_to_db,
@@ -324,31 +325,36 @@ def app_run(
                         use_adjuster_database=use_adjuster_database,
                         location_map=dp_location_map,
                         observer_name=model_config.observer_name,
-                        # model_name=model_name
                     )
 
-                    if model_config.save_uncurtailed & model_config.curtailment:
+                    if not model_config.curtailment:
+                        # if there is no curtailment, we can save the forecast normally
+                        save_forecast_for_site_group_partial(
+                            forecast_values=forecast_values,
+                            model_name=model_config.name,
+                        )
+
+                    elif model_config.save_uncurtailed & model_config.curtailment:
+                        # if there is curtailment, and we want to save the uncurtailed values
                         log.info("Saving uncurtailed forecast values...")
-                        model_name = model_config.name + "_uncurtailed"
-                    else:
-                        model_name = model_config.name
 
-                    save_forecast_for_site_group_partial(
-                        forecast_values=forecast_values,
-                        model_name=model_name,
-                    )
+                        save_forecast_for_site_group_partial(
+                            forecast_values=forecast_values,
+                            model_name=model_config.name + "_uncurtailed",
+                        )
 
                     if model_config.curtailment:
+                        # now saving the curtailed forecast values
                         log.info("Applying curtailment to forecast values...")
                         forecast_values = {k: curtailment.apply_curtailment(v) \
                                         for k, v in forecast_values.items()}
 
 
                         save_forecast_for_site_group_partial(
-                        forecast_values=forecast_values,
-                        model_name=model_config.name,
-                    )
-                        successful_runs += 1
+                            forecast_values=forecast_values,
+                            model_name=model_config.name,
+                        )
+                    successful_runs += 1
 
         log.info(
             f"Completed forecasts for {successful_runs} runs for "

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 import sys
+from functools import partial
 
 import click
 import pandas as pd
@@ -31,7 +32,7 @@ from site_forecast_app.models.pvnet.consts import root_data_path, satellite_path
 from site_forecast_app.models.pydantic_models import Model
 from site_forecast_app.save import (
     build_dp_location_map,
-    save_forecast,
+    save_forecast_for_site_group,
 )
 
 log = logging.getLogger(__name__)
@@ -307,42 +308,47 @@ def app_run(
                                        f"site_group_uuid={model_config.site_group_uuid}")
                 else:
 
-                    if model_config.curtailment:
-                        log.info("Applying curtailment to forecast values...")
-                        forecast_values = {k: curtailment.apply_curtailment(v) \
-                                        for k, v in forecast_values.items()}
-
                     # 4. Write forecast to DB or stdout
                     log.info(
                         f"Writing forecast for site_group_uuid={model_config.site_group_uuid}",
                     )
 
-                    for site in site_group:
-                        # Write forecast for one site at a time
-                        forecast = {
-                            "meta": {
-                                "location_uuid": site.location_uuid,
-                                "version": version,
-                                "timestamp": timestamp,
-                                "client_location_name": site.client_location_name,
-                                "capacity_kw": site.capacity_kw,
-                                "latitude": site.latitude,
-                                "longitude": site.longitude,
-                                "location_type": determine_location_type(site, model_config),
-                            },
-                            "values": forecast_values[site.ml_id],
-                        }
-                        save_forecast(
-                            session,
-                            forecast=forecast,
-                            write_to_db=write_to_db,
-                            ml_model_name=ml_model.name,
-                            ml_model_version=version,
-                            location_map=dp_location_map,
-                            use_adjuster_database=use_adjuster_database,
-                            use_adjuster=site.ml_id == 0,
-                        )
-                    successful_runs += 1
+                    save_forecast_for_site_group_partial = partial(save_forecast_for_site_group,
+                        db_session=session,
+                        # forecast_values=forecast_values,
+                        timestamp=timestamp,
+                        site_group=site_group,
+                        write_to_db=write_to_db,
+                        model_config=model_config,
+                        version=version,
+                        use_adjuster_database=use_adjuster_database,
+                        location_map=dp_location_map,
+                        observer_name=model_config.observer_name,
+                        # model_name=model_name
+                    )
+
+                    if model_config.save_uncurtailed & model_config.curtailment:
+                        log.info("Saving uncurtailed forecast values...")
+                        model_name = model_config.name + "_uncurtailed"
+                    else:
+                        model_name = model_config.name
+
+                    save_forecast_for_site_group_partial(
+                        forecast_values=forecast_values,
+                        model_name=model_name,
+                    )
+
+                    if model_config.curtailment:
+                        log.info("Applying curtailment to forecast values...")
+                        forecast_values = {k: curtailment.apply_curtailment(v) \
+                                        for k, v in forecast_values.items()}
+
+
+                        save_forecast_for_site_group_partial(
+                        forecast_values=forecast_values,
+                        model_name=model_config.name,
+                    )
+                        successful_runs += 1
 
         log.info(
             f"Completed forecasts for {successful_runs} runs for "

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -317,7 +317,7 @@ def app_run(
                         f"Writing forecast for site_group_uuid={model_config.site_group_uuid}",
                     )
 
-                    for site in sites_for_model:
+                    for site in site_group:
                         # Write forecast for one site at a time
                         forecast = {
                             "meta": {

--- a/site_forecast_app/models/all_models.yaml
+++ b/site_forecast_app/models/all_models.yaml
@@ -92,6 +92,7 @@ models:
     location_type: state
     summation_location_type: nation
     curtailment: true
+    save_uncurtailed: true
     # the generation data that is loaded
     observer_name: nednl_no_curtailment
     # the generation data used for the adjuster

--- a/site_forecast_app/models/all_models.yaml
+++ b/site_forecast_app/models/all_models.yaml
@@ -178,7 +178,7 @@ models:
     observer_name: nednl_no_curtailment
     observer_name_adjuster: nednl
     is_critical: false
-  - name: nl_regional_ecmwf_mo9_sat
+  - name: nl_regional_pv_ecmwf_mo9_sat
     # This model is trained on generation data where we have removed the curtailment
     # Also only 9 MO variables have been used, these have been removed:
     # - downward_shortwave_radiation_flux_gl
@@ -186,9 +186,9 @@ models:
     # - snow_depth_gl
     type: pvnet
     id: openclimatefix-models/pvnet_nl
-    version: 85ea039893412b66269b5035a6fcad306079cc64
+    version: e940d1d0eef4eabc55f098645be9287a75d58860
     summation_id: openclimatefix-models/pvnet_nl
-    summation_version: ef5616057c8de09360384be7589188e463cc22fe
+    summation_version: a266aaa4e6f59f9246a77b1ae9ec9ef662cdd7fd
     client: nl
     asset_type: pv
     satellite_scaling_method: constant

--- a/site_forecast_app/models/pydantic_models.py
+++ b/site_forecast_app/models/pydantic_models.py
@@ -84,6 +84,13 @@ class Model(BaseModel):
         description="Whether the model should apply curtailment to the forecasts.",
     )
 
+    save_uncurtailed: bool = Field(
+        False,
+        title="Save Uncurtailed",
+        description="Whether to save the uncurtailed forecasts. " \
+        "This will only be used if curtailment is enabled.",
+    )
+
     is_critical: bool = Field(
         True,
         title="Is Critical",

--- a/site_forecast_app/save/__init__.py
+++ b/site_forecast_app/save/__init__.py
@@ -17,7 +17,7 @@ from site_forecast_app.save.data_platform import (
     save_forecast_to_dataplatform,
     save_to_dataplatform,
 )
-from site_forecast_app.save.save import save_forecast
+from site_forecast_app.save.save import save_forecast, save_forecast_for_site_group
 from site_forecast_app.save.utils import limit_adjuster  # noqa: F401
 
 __all__ = [
@@ -32,4 +32,5 @@ __all__ = [
     "save_forecast",
     "save_forecast_to_dataplatform",
     "save_to_dataplatform",
+    "save_forecast_for_site_group",
 ]

--- a/site_forecast_app/save/save.py
+++ b/site_forecast_app/save/save.py
@@ -174,7 +174,6 @@ def save_forecast(
         f"version={forecast_meta['forecast_version']}:"
     )
     log.info(output)
-    log.info(f"\n{forecast_values_df.to_string()}\n")
 
     # Optionally push to the Data Platform
     if os.getenv("SAVE_TO_DATA_PLATFORM", "false").lower() == "true":

--- a/site_forecast_app/save/save.py
+++ b/site_forecast_app/save/save.py
@@ -7,8 +7,11 @@ import logging
 import os
 
 import pandas as pd
+from dp_sdk.ocf import dp
+from pvsite_datamodel.sqlmodels import LocationSQL  # noqa: TC002
 from sqlalchemy.orm import Session  # noqa: TC002
 
+from site_forecast_app.models.pydantic_models import Model  # noqa: TC001
 from site_forecast_app.save.data_platform import (
     save_forecast_to_dataplatform,  # noqa: F401  (re-exported via __init__)
     save_to_dataplatform,
@@ -16,6 +19,81 @@ from site_forecast_app.save.data_platform import (
 from site_forecast_app.save.database import write_forecast_to_db
 
 log = logging.getLogger(__name__)
+
+
+def determine_location_type(site: LocationSQL, model_config: Model) -> dp.LocationType:
+    """Determine the Data Platform LocationType based on site and model properties."""
+    if site.ml_id == 0:
+        loc_type = model_config.summation_location_type or "nation"
+    else:
+        loc_type = model_config.location_type
+
+    if loc_type == "nation":
+        return dp.LocationType.NATION
+    if loc_type == "state":
+        return dp.LocationType.STATE
+
+    return dp.LocationType.SITE
+
+
+def save_forecast_for_site_group(
+    db_session: Session,
+    forecast_values: dict,
+    timestamp: pd.Timestamp,
+    site_group: list,
+    write_to_db: bool = False,
+    model_config: Model | None = None,
+    version: str | None = None,
+    use_adjuster_database: bool = True,
+    location_map: dict[str, str] | None = None,
+    observer_name: str | None = None,
+    model_name: str | None = None,
+) -> None:
+    """Saves forecasts for a group of sites.
+
+    Args:
+        db_session: A SQLAlchemy session
+        forecast_values: dict (by site_id) of forecast values
+        timestamp: The timestamp for which the forecast is valid
+        site_group: The group of sites to save forecasts for
+        write_to_db: If true, forecast values are written to the DB, otherwise to stdout
+        model_config: Config of the ML model used for the forecast
+        version: Version of the ML model used for the forecast
+        use_adjuster_database: Make a new model adjusted by last 7 days of ME values.
+            Also controls whether an adjusted forecast is sent to the Data Platform.
+        adjuster_average_minutes: Minutes to average over when calculating adjuster values
+        location_map: Optional pre-fetched mapping of DP location name to UUID.
+            When provided, avoids a list_locations gRPC call per site.
+        observer_name: The name of the observer to use for the adjuster
+        model_name: Name of the ML model used for the forecast
+
+    """
+    for site in site_group:
+        # Write forecast for one site at a time
+        forecast = {
+            "meta": {
+                "location_uuid": site.location_uuid,
+                "version": version,
+                "timestamp": timestamp,
+                "client_location_name": site.client_location_name,
+                "capacity_kw": site.capacity_kw,
+                "latitude": site.latitude,
+                "longitude": site.longitude,
+                "location_type": determine_location_type(site, model_config),
+            },
+            "values": forecast_values[site.ml_id],
+        }
+        save_forecast(
+            db_session,
+            forecast=forecast,
+            write_to_db=write_to_db,
+            ml_model_name=model_name,
+            ml_model_version=version,
+            location_map=location_map,
+            use_adjuster_database=use_adjuster_database,
+            use_adjuster=site.ml_id == 0,
+            observer_name=observer_name,
+        )
 
 
 def save_forecast(

--- a/site_forecast_app/save/save.py
+++ b/site_forecast_app/save/save.py
@@ -61,7 +61,6 @@ def save_forecast_for_site_group(
         version: Version of the ML model used for the forecast
         use_adjuster_database: Make a new model adjusted by last 7 days of ME values.
             Also controls whether an adjusted forecast is sent to the Data Platform.
-        adjuster_average_minutes: Minutes to average over when calculating adjuster values
         location_map: Optional pre-fetched mapping of DP location name to UUID.
             When provided, avoids a list_locations gRPC call per site.
         observer_name: The name of the observer to use for the adjuster

--- a/tests/end_to_end/test_app.py
+++ b/tests/end_to_end/test_app.py
@@ -62,11 +62,11 @@ def test_app(
     assert result.exit_code == 0
 
     fv_per_hour = 4 # 15 min resolution = 4 values per hour
-    n_forecasts = 12 + 12*10 # 12 national models + 10 regional models times 12 regional sites
-    n_models = 12
+    n_forecasts = 13 + 12*11 # 13 national models + 11 regional models times 12 regional sites
+    n_models = 13
     # 2 national models times 1 site = 2
-    # 10 regional models times 1 national summation site = 10
-    # 10 regional models times 12 regional sites = 120
+    # 11 regional models times 1 national summation site = 11
+    # 11 regional models times 12 regional sites = 132
     # average number of forecast is:
     n_fv = ((36 * n_forecasts) / n_forecasts) * fv_per_hour
 

--- a/tests/integration/test_adjuster.py
+++ b/tests/integration/test_adjuster.py
@@ -1,6 +1,7 @@
 """Test for adjuster.py"""
 
 from datetime import datetime
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -88,8 +89,13 @@ def test_get_me_values_no_forecasts(db_session, sites, generation_db_values, ini
 
 
 @freeze_time(now)
-def test_adjust_forecast_with_adjuster(db_session, sites, generation_db_values, forecasts):  # noqa: ARG001
+@patch("site_forecast_app.adjuster.get_me_values")
+def test_adjust_forecast_with_adjuster(mock_get_me_values, db_session, sites):
     """Check forecast gets adjuster"""
+
+    mock_get_me_values.return_value = pd.DataFrame.from_dict({
+        "horizon_minutes": [1145,1200,1215], "me_kw": [101, 102, 103]})
+
     forecast_meta = {"timestamp_utc": datetime.now(), "location_uuid": sites[0].location_uuid}  # noqa: DTZ005
     forecast_values_df = pd.DataFrame(
         {
@@ -113,7 +119,7 @@ def test_adjust_forecast_with_adjuster(db_session, sites, generation_db_values, 
         db_session, forecast_meta, forecast_values_df, ml_model_name="test",
     )
 
-    # check that the forecast_values_df has been adjusted for the horizon_minutes=90
+    # check that the forecast_values_df has been adjusted for the horizon_minutes=1200
     original_p50 = forecast_values_df.loc[
         forecast_values_df["horizon_minutes"] == 1200, "probabilistic_values",
     ].iloc[0]["p50"]
@@ -127,7 +133,7 @@ def test_adjust_forecast_with_adjuster(db_session, sites, generation_db_values, 
     assert len(adjusted_forecast_df) == 5
 
     assert adjusted_forecast_df["forecast_power_kw"][0:4].sum() == 10.0
-    assert adjusted_forecast_df["forecast_power_kw"][4] != 5
+    assert adjusted_forecast_df["forecast_power_kw"][4] != 5 -101
 
     # note the way the tests are setup, only the horizon_minutes=90 has some ME values
 

--- a/tests/integration/test_app_functions.py
+++ b/tests/integration/test_app_functions.py
@@ -13,11 +13,11 @@ from pvsite_datamodel.sqlmodels import ForecastSQL, ForecastValueSQL, LocationGr
 from site_forecast_app.app import (
     get_sites,
     run_model,
-    save_forecast,
 )
 from site_forecast_app.data.generation import get_generation_data
 from site_forecast_app.models.pvnet.model import PVNetModel
 from site_forecast_app.models.pydantic_models import get_all_models
+from site_forecast_app.save import save_forecast
 
 mp.set_start_method("spawn", force=True)
 now = pd.Timestamp.now().floor("15min") + pd.Timedelta(minutes=1)


### PR DESCRIPTION
# Pull Request

## Description

- Add option to save uncurtailed forecasts
- Move save for all sites, into save.py
- Save uncurtailed forecasts for `nl_regional_pv_ecmwf_mo_sat`
- very small change to remove excess logging
- also, I mocked a test with the adjuster as it was flaky

https://github.com/openclimatefix/client-private/issues/471

## How Has This Been Tested?

- [x] CI tests + changed due to one extra forecast begining saved
- [x] ran with local dataplatform

<img width="1252" height="525" alt="Screenshot 2026-06-11 at 18 04 35" src="https://github.com/user-attachments/assets/d2a2040e-c2c7-49d6-b558-be2ea32b7ea7" />


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
