### PR TITLE
add observer_name_uncurtailed_adjuster and fix observer_name in save

### DIFF
--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -324,7 +324,7 @@ def app_run(
                         version=version,
                         use_adjuster_database=use_adjuster_database,
                         location_map=dp_location_map,
-                        observer_name=model_config.observer_name,
+                        observer_name=model_config.observer_name_adjuster,
                     )
 
                     if not model_config.curtailment:
@@ -332,6 +332,7 @@ def app_run(
                         save_forecast_for_site_group_partial(
                             forecast_values=forecast_values,
                             model_name=model_config.name,
+                            observer_name=model_config.observer_name_adjuster,
                         )
 
                     elif model_config.save_uncurtailed & model_config.curtailment:
@@ -341,6 +342,7 @@ def app_run(
                         save_forecast_for_site_group_partial(
                             forecast_values=forecast_values,
                             model_name=model_config.name + "_uncurtailed",
+                            observer_name=model_config.observer_name_uncurtailed_adjuster,
                         )
 
                     if model_config.curtailment:
@@ -353,6 +355,7 @@ def app_run(
                         save_forecast_for_site_group_partial(
                             forecast_values=forecast_values,
                             model_name=model_config.name,
+                            observer_name=model_config.observer_name_adjuster,
                         )
                     successful_runs += 1
 

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -324,7 +324,6 @@ def app_run(
                         version=version,
                         use_adjuster_database=use_adjuster_database,
                         location_map=dp_location_map,
-                        observer_name=model_config.observer_name_adjuster,
                     )
 
                     if not model_config.curtailment:

--- a/site_forecast_app/models/all_models.yaml
+++ b/site_forecast_app/models/all_models.yaml
@@ -92,11 +92,13 @@ models:
     location_type: state
     summation_location_type: nation
     curtailment: true
-    save_uncurtailed: true
     # the generation data that is loaded
     observer_name: nednl_no_curtailment
     # the generation data used for the adjuster
     observer_name_adjuster: nednl
+    # save the uncurtailed values too
+    save_uncurtailed: true
+    observer_name_uncurtailed_adjuster: nednl_no_curtailment
     # Uncurtailed model below
   - name: nl_regional_ecmwf_mo_sat
     type: pvnet

--- a/site_forecast_app/models/pydantic_models.py
+++ b/site_forecast_app/models/pydantic_models.py
@@ -52,6 +52,12 @@ class Model(BaseModel):
         description="The UUID of the site group that the model is for.",
     )
 
+    observer_name: str | None = Field(
+        None,
+        title="Observer Name",
+        description="The name of the observer to fetch from the DP generation data from",
+    )
+
     # Summation model requires a National site, which by convention has ml_id=0 and should be
     # added to the site_group alongside the regional sites for the model
     summation_id: str | None = Field(
@@ -78,6 +84,20 @@ class Model(BaseModel):
         description="The type of location for the summation outcome (site, state, or nation)",
     )
 
+    is_critical: bool = Field(
+        True,
+        title="Is Critical",
+        description="If this model must always be part of the critical set of models which should "
+        "always be run. Non-critical models are skipped when RUN_CRITICAL_MODELS_ONLY is true.",
+    )
+
+    observer_name_adjuster: str | None = Field(
+        None,
+        title="Observer Name for the adjuster",
+        description="The name of the observer to fetch from the DP use for the adjuster",
+    )
+
+    # curtailment options
     curtailment: bool = Field(
         False,
         title="Curtailment",
@@ -91,29 +111,11 @@ class Model(BaseModel):
         "This will only be used if curtailment is enabled.",
     )
 
-    is_critical: bool = Field(
-        True,
-        title="Is Critical",
-        description="If this model must always be part of the critical set of models which should "
-        "always be run. Non-critical models are skipped when RUN_CRITICAL_MODELS_ONLY is true.",
-    )
-
-    observer_name: str | None = Field(
-        None,
-        title="Observer Name",
-        description="The name of the observer to fetch DP generation data from",
-    )
-
-    observer_name_adjuster: str | None = Field(
-        None,
-        title="Observer Name for the adjuster",
-        description="The name of the observer to fetch DP use for the adjuster",
-    )
-
     observer_name_uncurtailed_adjuster: str | None = Field(
         None,
         title="Observer Name for the uncurtailed adjuster",
-        description="The name of the observer to fetch DP use for the uncurtailed adjuster",
+        description="The name of the observer to " \
+        "fetch from the DP use for the uncurtailed adjuster",
     )
 
 

--- a/site_forecast_app/models/pydantic_models.py
+++ b/site_forecast_app/models/pydantic_models.py
@@ -110,6 +110,12 @@ class Model(BaseModel):
         description="The name of the observer to fetch DP use for the adjuster",
     )
 
+    observer_name_uncurtailed_adjuster: str | None = Field(
+        None,
+        title="Observer Name for the uncurtailed adjuster",
+        description="The name of the observer to fetch DP use for the uncurtailed adjuster",
+    )
+
 
 class Models(BaseModel):
     """A group of ml models."""


### PR DESCRIPTION

# Pull Request

## Description

- make sure the save method is using the correct observer name for the adjuster (bug introduced in 1.3.24)
- add a new observer name for the uncurtailed model to use for the adjuster
- re-ordered pydantic model to group curtailment things together

#198 

## How Has This Been Tested?

- CI tests

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
