### PR TITLE
feat: generalize Data Platform interactions to support both SOLAR and…

### DIFF
--- a/site_forecast_app/data/generation.py
+++ b/site_forecast_app/data/generation.py
@@ -1,4 +1,5 @@
 """Functions for working with site generation data."""
+
 import asyncio
 import datetime as dt
 import logging
@@ -78,8 +79,10 @@ async def fetch_generation_from_dp(
 
 
 def get_generation_data(
-        db_session: Session, sites: list[LocationSQL], timestamp: pd.Timestamp,
-        observer_name: str | None = None,
+    db_session: Session,
+    sites: list[LocationSQL],
+    timestamp: pd.Timestamp,
+    observer_name: str | None = None,
 ) -> dict[str, pd.DataFrame | xr.Dataset]:
     """Load generation data from Database.
 
@@ -121,7 +124,9 @@ def get_generation_data(
 
 
 async def _get_site_generation_data(
-    db_session: Session, site: LocationSQL, timestamp: pd.Timestamp,
+    db_session: Session,
+    site: LocationSQL,
+    timestamp: pd.Timestamp,
     observer_name: str | None = None,
 ) -> dict[str, pd.DataFrame | xr.Dataset]:
     """Gets generation data values for a single site.
@@ -153,21 +158,25 @@ async def _get_site_generation_data(
             f"Reading from Data Platform for the location {site.client_location_name} "
             f"from {start} to {end}",
         )
-        if hasattr(site.asset_type, "name") and site.asset_type.name.lower() == "wind":
-            energy_source = dp.EnergySource.WIND
-        else:
-            energy_source = dp.EnergySource.SOLAR
+        from site_forecast_app.save.save import determine_energy_source
+
+        energy_source = determine_energy_source(site)
         dp_data = await fetch_generation_from_dp(
-            site.client_location_name, start, end, observer_name, energy_source=energy_source,
+            site.client_location_name,
+            start,
+            end,
+            observer_name,
+            energy_source=energy_source,
         )
         formatted_data = [(t, p, system_id) for t, p in dp_data]
     else:
         generation_data = get_pv_generation_by_sites(
-            session=db_session, site_uuids=[site.location_uuid], start_utc=start, end_utc=end,
+            session=db_session,
+            site_uuids=[site.location_uuid],
+            start_utc=start,
+            end_utc=end,
         )
-        formatted_data = [
-            (g.start_utc, g.generation_power_kw, system_id) for g in generation_data
-        ]
+        formatted_data = [(g.start_utc, g.generation_power_kw, system_id) for g in generation_data]
 
     if len(formatted_data) == 0:
         log.warning(f"No generation found for site {site.location_uuid}")
@@ -285,8 +294,8 @@ def filter_on_sun_elevation(generation_df: pd.DataFrame, site: LocationSQL) -> p
     generation_df = generation_df[~mask]
     return generation_df
 
-def format_generation_data(generation_xr: xr.Dataset,
-                            metadata_df: pd.DataFrame) -> xr.Dataset:
+
+def format_generation_data(generation_xr: xr.Dataset, metadata_df: pd.DataFrame) -> xr.Dataset:
     """Format generation data to schema pvnet expects.
 
     Args:
@@ -307,8 +316,7 @@ def format_generation_data(generation_xr: xr.Dataset,
     """
     # Clean and prepare metadata
     metadata = (
-        metadata_df
-        .assign(
+        metadata_df.assign(
             capacity_mwp=lambda df: df["capacity_kwp"] / 1000,
         )
         .drop(columns=["capacity_kwp"])
@@ -316,11 +324,7 @@ def format_generation_data(generation_xr: xr.Dataset,
     )
 
     # Prepare generation data, convert to MW
-    generation = (
-        generation_xr
-        .rename({"generation_kw": "generation_mw"})
-        / 1000
-    )
+    generation = generation_xr.rename({"generation_kw": "generation_mw"}) / 1000
 
     # Capacity: align to generation_xr
     capacity = metadata["capacity_mwp"].to_xarray().broadcast_like(generation)

--- a/site_forecast_app/data/generation.py
+++ b/site_forecast_app/data/generation.py
@@ -20,8 +20,10 @@ from site_forecast_app.save.data_platform import (
     fetch_dp_location_map,
     get_dataplatform_client,
 )
-from site_forecast_app.save.save import determine_energy_source
-from site_forecast_app.save.utils import ensure_timezone_aware
+from site_forecast_app.save.utils import (
+    determine_energy_source,
+    ensure_timezone_aware,
+)
 
 log = logging.getLogger(__name__)
 

--- a/site_forecast_app/data/generation.py
+++ b/site_forecast_app/data/generation.py
@@ -20,6 +20,7 @@ from site_forecast_app.save.data_platform import (
     fetch_dp_location_map,
     get_dataplatform_client,
 )
+from site_forecast_app.save.save import determine_energy_source
 from site_forecast_app.save.utils import ensure_timezone_aware
 
 log = logging.getLogger(__name__)
@@ -158,8 +159,6 @@ async def _get_site_generation_data(
             f"Reading from Data Platform for the location {site.client_location_name} "
             f"from {start} to {end}",
         )
-        from site_forecast_app.save.save import determine_energy_source
-
         energy_source = determine_energy_source(site)
         dp_data = await fetch_generation_from_dp(
             site.client_location_name,

--- a/site_forecast_app/data/generation.py
+++ b/site_forecast_app/data/generation.py
@@ -29,6 +29,7 @@ async def fetch_generation_from_dp(
     start: datetime,
     end: datetime,
     observer_name: str | None = None,
+    energy_source: dp.EnergySource = dp.EnergySource.SOLAR,
 ) -> list[tuple[datetime, float]]:
     """Fetch generation (observation) data from the Data Platform."""
     if not site_name:
@@ -46,7 +47,7 @@ async def fetch_generation_from_dp(
 
         req = dp.GetObservationsAsTimeseriesRequest(
             location_uuid=loc_uuid,
-            energy_source=dp.EnergySource.SOLAR,
+            energy_source=energy_source,
             observer_name=actual_observer_name,
             time_window=dp.TimeWindow(
                 start_timestamp_utc=ensure_timezone_aware(start).to_pydatetime()
@@ -152,8 +153,12 @@ async def _get_site_generation_data(
             f"Reading from Data Platform for the location {site.client_location_name} "
             f"from {start} to {end}",
         )
+        if hasattr(site.asset_type, "name") and site.asset_type.name.lower() == "wind":
+            energy_source = dp.EnergySource.WIND
+        else:
+            energy_source = dp.EnergySource.SOLAR
         dp_data = await fetch_generation_from_dp(
-            site.client_location_name, start, end, observer_name,
+            site.client_location_name, start, end, observer_name, energy_source=energy_source,
         )
         formatted_data = [(t, p, system_id) for t, p in dp_data]
     else:

--- a/site_forecast_app/save/data_platform.py
+++ b/site_forecast_app/save/data_platform.py
@@ -492,15 +492,20 @@ async def save_forecast_to_dataplatform(
 
     if use_adjuster:
         log.info(f"Building adjuster forecast for {client_location_name!r}")
-        adjusted_request = await make_forecaster_adjuster(
-            client=client,
-            location_uuid=target_uuid_str,
-            init_time_utc=init_time_utc,
-            forecast_values=forecast_values,
-            model_tag=model_tag,
-            forecaster=forecaster,
-            observer_name=observer_name,
-            energy_source=energy_source,
-        )
-        await client.create_forecast(adjusted_request)
-        log.info(f"Adjusted forecast submitted for {client_location_name!r}")
+        try:
+            adjusted_request = await make_forecaster_adjuster(
+                client=client,
+                location_uuid=target_uuid_str,
+                init_time_utc=init_time_utc,
+                forecast_values=forecast_values,
+                model_tag=model_tag,
+                forecaster=forecaster,
+                observer_name=observer_name,
+                energy_source=energy_source,
+            )
+            await client.create_forecast(adjusted_request)
+            log.info(f"Adjusted forecast submitted for {client_location_name!r}")
+        except Exception:
+            log.exception(
+                f"Failed to save adjusted forecast to Data Platform for {client_location_name!r}",
+            )

--- a/site_forecast_app/save/data_platform.py
+++ b/site_forecast_app/save/data_platform.py
@@ -7,7 +7,6 @@ import contextlib
 import json
 import logging
 import os
-import traceback
 from collections.abc import AsyncIterator  # noqa: TC003
 from datetime import UTC, datetime, timedelta
 from importlib.metadata import version
@@ -98,26 +97,23 @@ async def save_to_dataplatform(
         f"location_map_size={len(location_map) if location_map else None}",
     )
 
-    try:
-        async with get_dataplatform_client() as client:
-            await save_forecast_to_dataplatform(
-                forecast_df=forecast_df,
-                client_location_name=client_location_name,
-                model_tag=model_tag,
-                init_time_utc=init_time_utc,
-                client=client,
-                capacity_kw=capacity_kw,
-                latitude=forecast_meta.get("latitude"),
-                longitude=forecast_meta.get("longitude"),
-                location_type=forecast_meta.get("location_type", dp.LocationType.SITE),
-                location_map=location_map,
-                use_adjuster=use_adjuster,
-                observer_name=observer_name,
-            )
-        log.info(f"Save complete for location={client_location_name!r}")
-    except Exception as e:
-        log.error(f"Failed to save forecast to Data Platform: {e}")
-        log.error(traceback.format_exc())
+    async with get_dataplatform_client() as client:
+        await save_forecast_to_dataplatform(
+            forecast_df=forecast_df,
+            client_location_name=client_location_name,
+            model_tag=model_tag,
+            init_time_utc=init_time_utc,
+            client=client,
+            capacity_kw=capacity_kw,
+            latitude=forecast_meta.get("latitude"),
+            longitude=forecast_meta.get("longitude"),
+            location_type=forecast_meta.get("location_type", dp.LocationType.SITE),
+            location_map=location_map,
+            use_adjuster=use_adjuster,
+            observer_name=observer_name,
+            energy_source=forecast_meta.get("energy_source", dp.EnergySource.SOLAR),
+        )
+    log.info(f"Save complete for location={client_location_name!r}")
 
 
 async def make_forecaster_adjuster(
@@ -128,6 +124,7 @@ async def make_forecaster_adjuster(
     model_tag: str,
     forecaster: dp.Forecaster,
     observer_name: str | None = None,
+    energy_source: dp.EnergySource = dp.EnergySource.SOLAR,
 ) -> dp.CreateForecastRequest:
     """Build an adjusted forecast request using week-average deltas from the Data Platform.
 
@@ -144,6 +141,7 @@ async def make_forecaster_adjuster(
         forecaster: The base forecaster object (used to fetch deltas).
         observer_name: The name of the observer to use for the adjuster
             (defaults to env var OBSERVER_NAME or "nednl").
+        energy_source: The energy source of the location (SOLAR or WIND).
 
     Returns:
         A ``CreateForecastRequest`` for the adjusted forecast.
@@ -153,7 +151,7 @@ async def make_forecaster_adjuster(
 
     deltas_request = dp.GetWeekAverageDeltasRequest(
         location_uuid=location_uuid,
-        energy_source=dp.EnergySource.SOLAR,
+        energy_source=energy_source,
         pivot_timestamp_utc=init_time_utc.replace(tzinfo=UTC),
         forecaster=forecaster,
         observer_name=observer_name,
@@ -168,7 +166,7 @@ async def make_forecaster_adjuster(
     location = await client.get_location(
         dp.GetLocationRequest(
             location_uuid=location_uuid,
-            energy_source=dp.EnergySource.SOLAR,
+            energy_source=energy_source,
             include_geometry=False,
         ),
     )
@@ -205,7 +203,7 @@ async def make_forecaster_adjuster(
     return dp.CreateForecastRequest(
         forecaster=adjuster_forecaster,
         location_uuid=location_uuid,
-        energy_source=dp.EnergySource.SOLAR,
+        energy_source=energy_source,
         init_time_utc=init_time_utc.replace(tzinfo=UTC),
         values=adjusted_values,
     )
@@ -241,12 +239,13 @@ async def resolve_target_uuid(
 async def get_location_capacity(
     client: DataPlatformClient,
     target_uuid_str: str,
+    energy_source: dp.EnergySource = dp.EnergySource.SOLAR,
 ) -> int:
     """Fetch effective capacity (watts) for an existing DP location."""
     location = await client.get_location(
         dp.GetLocationRequest(
             location_uuid=target_uuid_str,
-            energy_source=dp.EnergySource.SOLAR,
+            energy_source=energy_source,
             include_geometry=False,
         ),
     )
@@ -261,6 +260,7 @@ async def create_new_location(
     longitude: float | None,
     init_time_utc: datetime,
     location_type: dp.LocationType = dp.LocationType.SITE,
+    energy_source: dp.EnergySource = dp.EnergySource.SOLAR,
 ) -> str:
     """Create a new location in the Data Platform and return its UUID."""
     log.warning(
@@ -275,7 +275,7 @@ async def create_new_location(
     try:
         create_req = dp.CreateLocationRequest(
             location_name=client_location_name,
-            energy_source=dp.EnergySource.SOLAR,
+            energy_source=energy_source,
             geometry_wkt=wkt,
             effective_capacity_watts=capacity_watts,
             location_type=location_type,
@@ -391,6 +391,7 @@ async def save_forecast_to_dataplatform(
     location_map: dict[str, str] | None = None,
     use_adjuster: bool = True,
     observer_name: str | None = None,
+    energy_source: dp.EnergySource = dp.EnergySource.SOLAR,
 ) -> None:
     """Save forecast to the Data Platform."""
     app_version = version("site-forecast-app")
@@ -431,12 +432,17 @@ async def save_forecast_to_dataplatform(
             longitude,
             init_time_utc,
             location_type=location_type,
+            energy_source=energy_source,
         )
         log.info(f"created location uuid={target_uuid_str}")
     else:
         log.info(f"location already exists uuid={target_uuid_str}")
 
-    capacity_watts = await get_location_capacity(client=client, target_uuid_str=target_uuid_str)
+    capacity_watts = await get_location_capacity(
+        client=client,
+        target_uuid_str=target_uuid_str,
+        energy_source=energy_source,
+    )
     log.info(
         f"capacity_watts={capacity_watts:,}  ({capacity_watts / 1000:,.1f} kW)",
     )
@@ -470,7 +476,7 @@ async def save_forecast_to_dataplatform(
     base_request = dp.CreateForecastRequest(
         forecaster=forecaster,
         location_uuid=target_uuid_str,
-        energy_source=dp.EnergySource.SOLAR,
+        energy_source=energy_source,
         init_time_utc=init_time_utc,
         values=forecast_values,
         metadata=Struct(fields={"app_version": Value(string_value=app_version)}),
@@ -486,20 +492,15 @@ async def save_forecast_to_dataplatform(
 
     if use_adjuster:
         log.info(f"Building adjuster forecast for {client_location_name!r}")
-        try:
-            adjusted_request = await make_forecaster_adjuster(
-                client=client,
-                location_uuid=target_uuid_str,
-                init_time_utc=init_time_utc,
-                forecast_values=forecast_values,
-                model_tag=model_tag,
-                forecaster=forecaster,
-                observer_name=observer_name,
-            )
-            await client.create_forecast(adjusted_request)
-            log.info(f"Adjusted forecast submitted for {client_location_name!r}")
-        except Exception:
-            log.error(
-                f"Failed to save adjusted forecast to Data Platform for {client_location_name!r}\n"
-                + traceback.format_exc(),
-            )
+        adjusted_request = await make_forecaster_adjuster(
+            client=client,
+            location_uuid=target_uuid_str,
+            init_time_utc=init_time_utc,
+            forecast_values=forecast_values,
+            model_tag=model_tag,
+            forecaster=forecaster,
+            observer_name=observer_name,
+            energy_source=energy_source,
+        )
+        await client.create_forecast(adjusted_request)
+        log.info(f"Adjusted forecast submitted for {client_location_name!r}")

--- a/site_forecast_app/save/save.py
+++ b/site_forecast_app/save/save.py
@@ -36,6 +36,14 @@ def determine_location_type(site: LocationSQL, model_config: Model) -> dp.Locati
     return dp.LocationType.SITE
 
 
+def determine_energy_source(site: LocationSQL) -> dp.EnergySource:
+    """Determine the Data Platform EnergySource based on site asset type."""
+    asset_type = site.asset_type.name if hasattr(site.asset_type, "name") else str(site.asset_type)
+    if asset_type.lower() == "wind":
+        return dp.EnergySource.WIND
+    return dp.EnergySource.SOLAR
+
+
 def save_forecast_for_site_group(
     db_session: Session,
     forecast_values: dict,
@@ -79,6 +87,7 @@ def save_forecast_for_site_group(
                 "latitude": site.latitude,
                 "longitude": site.longitude,
                 "location_type": determine_location_type(site, model_config),
+                "energy_source": determine_energy_source(site),
             },
             "values": forecast_values[site.ml_id],
         }
@@ -137,6 +146,7 @@ def save_forecast(
         "latitude": forecast["meta"].get("latitude"),
         "longitude": forecast["meta"].get("longitude"),
         "location_type": forecast["meta"].get("location_type"),
+        "energy_source": forecast["meta"].get("energy_source", dp.EnergySource.SOLAR),
     }
 
     forecast_values_df = pd.DataFrame(forecast["values"])

--- a/site_forecast_app/save/save.py
+++ b/site_forecast_app/save/save.py
@@ -17,6 +17,7 @@ from site_forecast_app.save.data_platform import (
     save_to_dataplatform,
 )
 from site_forecast_app.save.database import write_forecast_to_db
+from site_forecast_app.save.utils import determine_energy_source
 
 log = logging.getLogger(__name__)
 
@@ -34,14 +35,6 @@ def determine_location_type(site: LocationSQL, model_config: Model) -> dp.Locati
         return dp.LocationType.STATE
 
     return dp.LocationType.SITE
-
-
-def determine_energy_source(site: LocationSQL) -> dp.EnergySource:
-    """Determine the Data Platform EnergySource based on site asset type."""
-    asset_type = site.asset_type.name if hasattr(site.asset_type, "name") else str(site.asset_type)
-    if asset_type.lower() == "wind":
-        return dp.EnergySource.WIND
-    return dp.EnergySource.SOLAR
 
 
 def save_forecast_for_site_group(
@@ -167,6 +160,7 @@ def save_forecast(
     # Persist adjuster forecast to DB
     if use_adjuster_database and ml_model_name is not None:
         from site_forecast_app.save.database import adjust_and_save_forecast
+
         adjust_and_save_forecast(
             db_session,
             forecast_meta,

--- a/site_forecast_app/save/utils.py
+++ b/site_forecast_app/save/utils.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 import pandas as pd
+from dp_sdk.ocf import dp
+from pvsite_datamodel.sqlmodels import LocationSQL  # noqa: TC002
 
 
 def add_or_convert_to_utc(timestamp: object) -> pd.Timestamp:
@@ -38,3 +40,11 @@ def limit_adjuster(delta_fraction: float, value_fraction: float, capacity_mw: fl
         delta_fraction = -max_delta_absolute
 
     return delta_fraction
+
+
+def determine_energy_source(site: LocationSQL) -> dp.EnergySource:
+    """Determine the Data Platform EnergySource based on site asset type."""
+    asset_type = site.asset_type.name if hasattr(site.asset_type, "name") else str(site.asset_type)
+    if asset_type.lower() == "wind":
+        return dp.EnergySource.WIND
+    return dp.EnergySource.SOLAR

--- a/tests/unit/test_fetch_generation_data_from_dp.py
+++ b/tests/unit/test_fetch_generation_data_from_dp.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from dp_sdk.ocf import dp
 
 from site_forecast_app.data.generation import fetch_generation_from_dp
 
@@ -82,3 +83,46 @@ async def test_fetch_generation_from_dp_no_site():
         )
         assert data == []
         mock_client.get_observations_as_timeseries.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_generation_from_dp_wind():
+    """Test fetching wind generation data from the Data Platform."""
+    mock_client = AsyncMock()
+
+    mock_obs_val1 = MagicMock()
+    mock_ts = datetime(2024, 6, 1, 10, 0, tzinfo=UTC)
+    mock_obs_val1.timestamp_utc = mock_ts
+    mock_obs_val1.value_fraction = 0.5
+    mock_obs_val1.effective_capacity_watts = 2000  # 2 kW
+
+    mock_obs_resp = MagicMock()
+    mock_obs_resp.values = [mock_obs_val1]
+    mock_client.get_observations_as_timeseries.return_value = mock_obs_resp
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__.return_value = mock_client
+
+    with (
+        patch(
+            "site_forecast_app.data.generation.get_dataplatform_client",
+            return_value=mock_ctx,
+        ),
+        patch(
+            "site_forecast_app.data.generation.fetch_dp_location_map",
+            return_value={"test-site": "uuid-123"},
+        ),
+    ):
+        data = await fetch_generation_from_dp(
+            "test-site",
+            datetime(2024, 6, 1, tzinfo=UTC),
+            datetime(2024, 6, 2, tzinfo=UTC),
+            energy_source=dp.EnergySource.WIND,
+        )
+
+        assert len(data) == 1
+        assert data[0][1] == 1.0
+
+        mock_client.get_observations_as_timeseries.assert_called_once()
+        req = mock_client.get_observations_as_timeseries.call_args[0][0]
+        assert req.energy_source == dp.EnergySource.WIND

--- a/uv.lock
+++ b/uv.lock
@@ -744,7 +744,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/e8/2e1462c8fdbe0f210feb5ac7ad2d9029af8be3bf45bd9fa39765f821642f/greenlet-3.3.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5fd23b9bc6d37b563211c6abbb1b3cab27db385a4449af5c32e932f93017080c", size = 274974, upload-time = "2026-01-23T15:31:02.891Z" },
     { url = "https://files.pythonhosted.org/packages/7e/a8/530a401419a6b302af59f67aaf0b9ba1015855ea7e56c036b5928793c5bd/greenlet-3.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09f51496a0bfbaa9d74d36a52d2580d1ef5ed4fdfcff0a73730abfbbbe1403dd", size = 577175, upload-time = "2026-01-23T16:00:56.213Z" },
     { url = "https://files.pythonhosted.org/packages/8e/89/7e812bb9c05e1aaef9b597ac1d0962b9021d2c6269354966451e885c4e6b/greenlet-3.3.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb0feb07fe6e6a74615ee62a880007d976cf739b6669cce95daa7373d4fc69c5", size = 590401, upload-time = "2026-01-23T16:05:26.365Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ae/e2d5f0e59b94a2269b68a629173263fa40b63da32f5c231307c349315871/greenlet-3.3.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:67ea3fc73c8cd92f42467a72b75e8f05ed51a0e9b1d15398c913416f2dafd49f", size = 601161, upload-time = "2026-01-23T16:15:53.456Z" },
     { url = "https://files.pythonhosted.org/packages/5c/ae/8d472e1f5ac5efe55c563f3eabb38c98a44b832602e12910750a7c025802/greenlet-3.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39eda9ba259cc9801da05351eaa8576e9aa83eb9411e8f0c299e05d712a210f2", size = 590272, upload-time = "2026-01-23T15:32:49.411Z" },
     { url = "https://files.pythonhosted.org/packages/a8/51/0fde34bebfcadc833550717eade64e35ec8738e6b097d5d248274a01258b/greenlet-3.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e2e7e882f83149f0a71ac822ebf156d902e7a5d22c9045e3e0d1daf59cee2cc9", size = 1550729, upload-time = "2026-01-23T16:04:20.867Z" },
     { url = "https://files.pythonhosted.org/packages/16/c9/2fb47bee83b25b119d5a35d580807bb8b92480a54b68fef009a02945629f/greenlet-3.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:80aa4d79eb5564f2e0a6144fcc744b5a37c56c4a92d60920720e99210d88db0f", size = 1615552, upload-time = "2026-01-23T15:33:45.743Z" },
@@ -1239,7 +1238,7 @@ wheels = [
 
 [[package]]
 name = "ocf-data-sampler"
-version = "1.0.9"
+version = "1.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dask" },
@@ -1260,9 +1259,9 @@ dependencies = [
     { name = "xarray-tensorstore" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/25/6d07761b412f741a9dee06cd4e2f42edf4302695c1beece96fbc0830b9a3/ocf_data_sampler-1.0.9.tar.gz", hash = "sha256:f1f2eedfa4fe50154210c08a4eb14b5cdd860b63d5a8061ddb4b9404d29eb36b", size = 7343863, upload-time = "2026-01-19T17:55:23.37Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/0e/224a433aa65075b622b6cd5748d5cf8b2a9f77cea792b09abc2bbd52a53c/ocf_data_sampler-1.0.17.tar.gz", hash = "sha256:e55f22efa2ec817039bebcd673d14a3c21c39582eca10614f93ba0521e642342", size = 7344266, upload-time = "2026-03-26T10:16:55.096Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/65/6fa3281a270c9bcf8c8284b4d5dc48861fb0d811f5d992aab55ef5253396/ocf_data_sampler-1.0.9-py3-none-any.whl", hash = "sha256:1bd107dfad92ca53692e43e99844c5c1e57b5464546a9756d92111e24bfd2d5b", size = 7369144, upload-time = "2026-01-19T17:55:21.25Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2c/6704e8bb127a0cb8d363d1cd4c0a2fc4d107bc77a3892d4156762eb917bf/ocf_data_sampler-1.0.17-py3-none-any.whl", hash = "sha256:d594364073cdaa609dc76230dfdbe83a39e7cd7fe2e23deb3fbea54e72d292f8", size = 7368621, upload-time = "2026-03-26T10:16:57.472Z" },
 ]
 
 [[package]]
@@ -2135,7 +2134,7 @@ requires-dist = [
     { name = "grpclib", specifier = ">=0.4.7" },
     { name = "huggingface-hub", specifier = "==0.20.3" },
     { name = "numpy", specifier = "==1.26.4" },
-    { name = "ocf-data-sampler", specifier = "==1.0.9" },
+    { name = "ocf-data-sampler", specifier = "==1.0.17" },
     { name = "pandas", specifier = "==2.2.3" },
     { name = "pvlib", specifier = "==0.12.0" },
     { name = "pvnet", specifier = "==5.3.7" },


### PR DESCRIPTION
feat: support WIND energy sources

# Pull Request

## Description

This pull request generalizes Data Platform interactions to support both SOLAR and WIND energy sources, rather than hardcoding SOLAR.

Key changes:
- **Data Retrieval (`generation.py`)**: Generalizes `fetch_generation_from_dp` to accept an `energy_source` parameter. It now detects if `site.asset_type` is `"wind"` and fetches from the Data Platform using `dp.EnergySource.WIND`.
- **Forecast Saving (`data_platform.py`)**: Updates `save_to_dataplatform`, `make_forecaster_adjuster`, `get_location_capacity`, `create_new_location`, and `save_forecast_to_dataplatform` to accept and handle an `energy_source` parameter dynamically instead of hardcoding `dp.EnergySource.SOLAR`.
- **Metadata Handling (`save.py`)**: Introduces `determine_energy_source` to parse the site asset type and retrieve the correct energy source enum, passing it downstream via forecast metadata.
Fixes #

## How Has This Been Tested?

The changes were verified by adding a new unit test for retrieving wind observations and running unit tests.

- [x] Unit tests added: `test_fetch_generation_data_from_dp_wind` in [test_fetch_generation_data_from_dp.py](file:///Users/pavankulkarni/Documents/code/site-forecast-app/tests/unit/test_fetch_generation_data_from_dp.py) verifies correct requests are made to the Data Platform client when the energy source is set to WIND.
- [x] Checked with existing pytest suite.


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
