### PR TITLE
Pass asset type through to model class

### DIFF
--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -266,6 +266,7 @@ def app_run(
                     satellite_scaling_method=model_config.satellite_scaling_method,
                     summation_version=model_config.summation_version,
                     summation_repo = model_config.summation_id,
+                    asset_type=model_config.asset_type,
                 )
 
                 log.info(f"{ml_model.site_uuid} model loaded")


### PR DESCRIPTION
# Pull Request

## Description

Asset type was accidentally removed from being included in the model class [here](https://github.com/openclimatefix/site-forecast-app/pull/195) this meant that the wind models were also having their forecasts set to 0 at night along with the PV forecasts, this should stop that since the logic is already included just need to pass the asset type from config  
