### PR TITLE
Fix sat india check

### DIFF
--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -50,9 +50,9 @@ sentry_sdk.set_tag("version", __version__)
 
 def get_sites(
     db_session: Session,
+    country: str,
+    client_name: str,
     model_config: Model | None = None,
-    country: str = "nl",
-    client_name: str = "nl",
 ) -> list[LocationSQL]:
     """Gets all available sites.
 
@@ -61,6 +61,7 @@ def get_sites(
             model_config: The model configuration to use
             country: The country to get sites for
             client_name: The client name to get sites for
+            model_config: The model configuration to use
 
     Returns:
             A list of LocationSQL objects
@@ -178,7 +179,11 @@ def app_run(
     logging.basicConfig(stream=sys.stdout, level=getattr(logging, log_level.upper()))
 
     log.info(f"Running site forecast app:{version}")
-    client_name = os.getenv("CLIENT_NAME", "nl")
+
+    # Get environment variables
+    url = os.environ["DB_URL"]
+    client_name = os.environ["CLIENT_NAME"]
+    country = os.environ["COUNTRY"]
     save_to_data_platform = os.getenv("SAVE_TO_DATA_PLATFORM", "false").lower() == "true"
 
     if timestamp is None:
@@ -190,11 +195,7 @@ def app_run(
         timestamp = pd.Timestamp(timestamp).floor("15min")
 
     # 0. Initialise DB connection
-    url = os.environ["DB_URL"]
     db_conn = DatabaseConnection(url, echo=False)
-    country = os.environ.get("COUNTRY", None)
-    if country is None:
-        raise ValueError("COUNTRY environment variable must be set")
 
     log.info(f"Country {country}...")
     log.info(f"write_to_db {write_to_db}...")
@@ -203,7 +204,7 @@ def app_run(
         # 1. Load data/models
         run_critical_only = os.getenv("RUN_CRITICAL_MODELS_ONLY", "false").lower() == "true"
         all_model_configs = get_all_models(
-            client_abbreviation=os.getenv("CLIENT_NAME", "nl"),
+            client_abbreviation=client_name,
             get_critical_only=run_critical_only,
         )
         successful_runs = 0
@@ -270,6 +271,7 @@ def app_run(
                     summation_version=model_config.summation_version,
                     summation_repo = model_config.summation_id,
                     asset_type=model_config.asset_type,
+                    client_name=client_name,
                 )
 
                 log.info(f"{ml_model.site_uuid} model loaded")

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -192,7 +192,10 @@ def app_run(
     # 0. Initialise DB connection
     url = os.environ["DB_URL"]
     db_conn = DatabaseConnection(url, echo=False)
-    country = os.environ.get("COUNTRY", "nl")
+    country = os.environ.get("COUNTRY", None)
+    if country is None:
+        raise ValueError("COUNTRY environment variable must be set")
+
     log.info(f"Country {country}...")
     log.info(f"write_to_db {write_to_db}...")
 

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -277,6 +277,7 @@ def app_run(
                     data_config_filename=ml_model.populated_data_config_filename,
                     t0=timestamp,
                     sat_datetimes=get_valid_satellite_times(satellite_path),
+                    country=country,
                 ):
                     log.warning(
                         f"Skipping model {model_config.name} for site_group_uuid="

--- a/site_forecast_app/data/satellite.py
+++ b/site_forecast_app/data/satellite.py
@@ -233,7 +233,7 @@ def check_model_satellite_inputs_available(
                 interval_end_minutes,
                 np.array(input_config.satellite.dropout_timedeltas_minutes).min(),
             )
-
+        # assume all European satellite data used in this app is 5min here 
         frequency = "15min" if country == "india" else "5min"
 
         expected_datetimes = pd.date_range(

--- a/site_forecast_app/data/satellite.py
+++ b/site_forecast_app/data/satellite.py
@@ -233,7 +233,7 @@ def check_model_satellite_inputs_available(
                 interval_end_minutes,
                 np.array(input_config.satellite.dropout_timedeltas_minutes).min(),
             )
-        # assume all European satellite data used in this app is 5min here 
+        # assume all European satellite data used in this app is 5min here
         frequency = "15min" if country == "india" else "5min"
 
         expected_datetimes = pd.date_range(

--- a/site_forecast_app/data/satellite.py
+++ b/site_forecast_app/data/satellite.py
@@ -188,6 +188,7 @@ def check_model_satellite_inputs_available(
     data_config_filename: str,
     t0: pd.Timestamp,
     sat_datetimes: pd.DatetimeIndex | None,
+    country: str,
 ) -> bool:
     """Checks whether the model can be run given the current satellite delay.
 
@@ -195,6 +196,7 @@ def check_model_satellite_inputs_available(
         data_config_filename: Path to the data configuration file
         t0: The init-time of the forecast
         sat_datetimes: The available satellite timestamps
+        country: The country for which the model is being run
 
     Returns:
         bool: Whether the satellite data satisfies that specified in the config
@@ -232,10 +234,12 @@ def check_model_satellite_inputs_available(
                 np.array(input_config.satellite.dropout_timedeltas_minutes).min(),
             )
 
+        frequency = "15min" if country == "india" else "5min"
+
         expected_datetimes = pd.date_range(
             t0 + pd.Timedelta(f"{int(interval_start_minutes)}min"),
             t0 + pd.Timedelta(f"{int(interval_end_minutes)}min"),
-            freq="5min",
+            freq=frequency,
         )
 
         # Check if any of the expected datetimes are missing

--- a/site_forecast_app/models/pvnet/model.py
+++ b/site_forecast_app/models/pvnet/model.py
@@ -307,7 +307,7 @@ class PVNetModel:
         # Remove negative values
         values_df["forecast_power_kw"] = values_df["forecast_power_kw"].clip(lower=0.0)
 
-        if self.asset_type == "wind" and self.client == "ruvnl":
+        if self.asset_type == "wind" and self.client_name == "ruvnl":
             log.info("Feathering the forecast to the lastest value of generation")
             values_df = feather_forecast(
                 values_df,

--- a/site_forecast_app/models/pvnet/model.py
+++ b/site_forecast_app/models/pvnet/model.py
@@ -60,10 +60,10 @@ class PVNetModel:
         hf_version: str,
         name: str,
         site_uuid: str,
+        asset_type: str,
         satellite_scaling_method: str = "constant",
         summation_repo: str | None = None,
         summation_version: str | None = None,
-        asset_type: str = "pv",
     ) -> None:
         """Initializer for the model."""
         self.id = hf_repo

--- a/site_forecast_app/models/pvnet/model.py
+++ b/site_forecast_app/models/pvnet/model.py
@@ -61,6 +61,7 @@ class PVNetModel:
         name: str,
         site_uuid: str,
         asset_type: str,
+        client_name: str,
         satellite_scaling_method: str = "constant",
         summation_repo: str | None = None,
         summation_version: str | None = None,
@@ -75,10 +76,10 @@ class PVNetModel:
         self.summation_repo = summation_repo
         self.summation_version = summation_version
         self.asset_type = asset_type
+        self.client_name = client_name
 
         log.info(f"Model initialised at t0={self.t0}")
 
-        self.client = os.getenv("CLIENT_NAME", "nl")
         self.hf_token = os.getenv("HUGGINGFACE_TOKEN", None)
 
         if self.hf_token is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,11 @@ def config_filename() -> str:
     """Path to the test data config yaml."""
     return f"{test_data_dir}/test.yaml"
 
+@pytest.fixture(scope="session")
+def config_india_sat_filename() -> str:
+    """Path to the test data config yaml."""
+    return f"{test_data_dir}/test_india_sat.yaml"
+
 
 @pytest.fixture(scope="session")
 def engine():

--- a/tests/integration/test_app_functions.py
+++ b/tests/integration/test_app_functions.py
@@ -26,7 +26,7 @@ now = pd.Timestamp.now().floor("15min") + pd.Timedelta(minutes=1)
 def test_get_sites(db_session, sites):
     """Test for correct site ids"""
 
-    sites = get_sites(db_session)
+    sites = get_sites(db_session, client_name="nl", country="nl")
     sites = sorted(sites, key=lambda s: s.client_location_id)
 
     assert len(sites) == 13
@@ -50,7 +50,7 @@ def test_get_sites_with_model_config(db_session, sites):
     model_config.client = None
     model_config.site_group_uuid = location_group.location_group_uuid
 
-    sites = get_sites(db_session, model_config=model_config)
+    sites = get_sites(db_session, model_config=model_config, client_name="nl", country="nl")
     sites = sorted(sites, key=lambda s: s.client_location_id)
 
     assert len(sites) == 16
@@ -85,6 +85,7 @@ def test_get_model(
         name="test",
         site_uuid=str(gen_sites[0].location_uuid),
         asset_type="pv",
+        client_name="nl",
     )
 
     assert hasattr(model, "version")
@@ -121,6 +122,7 @@ def test_run_model(
         name="test",
         site_uuid=str(uuid.uuid4()),
         asset_type="pv",
+        client_name="nl",
     )
     forecast = run_model(model=model, timestamp=init_timestamp)
 

--- a/tests/integration/test_app_functions.py
+++ b/tests/integration/test_app_functions.py
@@ -84,6 +84,7 @@ def test_get_model(
         hf_repo=ml_model.id,
         name="test",
         site_uuid=str(gen_sites[0].location_uuid),
+        asset_type="pv",
     )
 
     assert hasattr(model, "version")
@@ -119,6 +120,7 @@ def test_run_model(
         hf_repo=ml_model.id,
         name="test",
         site_uuid=str(uuid.uuid4()),
+        asset_type="pv",
     )
     forecast = run_model(model=model, timestamp=init_timestamp)
 

--- a/tests/test_data/test_india_sat.yaml
+++ b/tests/test_data/test_india_sat.yaml
@@ -1,0 +1,27 @@
+general:
+  description: Test data config for site-forecast-app
+  name: test
+input_data:
+  satellite:
+    channels:
+    - IR_016
+    - VIS008
+    - WV_062
+    dropout_fraction: 0.0
+    dropout_timedeltas_minutes: []
+    image_size_pixels_height: 24
+    image_size_pixels_width: 24
+    interval_end_minutes: -30
+    interval_start_minutes: -60
+    normalisation_constants:
+      IR_016:
+        mean: 0.17594202
+        std: 0.21462157
+      VIS008:
+        mean: 0.11426069
+        std: 0.13090034
+      WV_062:
+        mean: 0.7359355
+        std: 0.16111417
+    time_resolution_minutes: 15
+    zarr_path: PLACEHOLDER.zarr

--- a/tests/unit/data/test_satellite.py
+++ b/tests/unit/data/test_satellite.py
@@ -85,6 +85,12 @@ def test_check_model_satellite_inputs_available(config_filename) -> None:
 
     assert check_model_satellite_inputs_available(config_filename, t0, sat_datetime_1, country="nl")
     assert check_model_satellite_inputs_available(config_filename, t0, sat_datetime_2, country="nl")
-    assert not check_model_satellite_inputs_available(config_filename, t0, sat_datetime_3, country="nl")
-    assert not check_model_satellite_inputs_available(config_filename, t0, sat_datetime_4, country="nl")
-    assert not check_model_satellite_inputs_available(config_filename, t0, sat_datetime_5, country="nl")
+    assert not check_model_satellite_inputs_available(
+        config_filename, t0, sat_datetime_3, country="nl",
+    )
+    assert not check_model_satellite_inputs_available(
+        config_filename, t0, sat_datetime_4, country="nl",
+    )
+    assert not check_model_satellite_inputs_available(
+        config_filename, t0, sat_datetime_5, country="nl",
+    )

--- a/tests/unit/data/test_satellite.py
+++ b/tests/unit/data/test_satellite.py
@@ -83,8 +83,8 @@ def test_check_model_satellite_inputs_available(config_filename) -> None:
     sat_datetime_4 = pd.to_datetime([t for t in sat_datetime_1 if t != t0 - pd.Timedelta("30min")])
     sat_datetime_5 = pd.to_datetime([t for t in sat_datetime_1 if t != t0 - pd.Timedelta("60min")])
 
-    assert check_model_satellite_inputs_available(config_filename, t0, sat_datetime_1)
-    assert check_model_satellite_inputs_available(config_filename, t0, sat_datetime_2)
-    assert not check_model_satellite_inputs_available(config_filename, t0, sat_datetime_3)
-    assert not check_model_satellite_inputs_available(config_filename, t0, sat_datetime_4)
-    assert not check_model_satellite_inputs_available(config_filename, t0, sat_datetime_5)
+    assert check_model_satellite_inputs_available(config_filename, t0, sat_datetime_1, country="nl")
+    assert check_model_satellite_inputs_available(config_filename, t0, sat_datetime_2, country="nl")
+    assert not check_model_satellite_inputs_available(config_filename, t0, sat_datetime_3, country="nl")
+    assert not check_model_satellite_inputs_available(config_filename, t0, sat_datetime_4, country="nl")
+    assert not check_model_satellite_inputs_available(config_filename, t0, sat_datetime_5, country="nl")

--- a/tests/unit/data/test_satellite.py
+++ b/tests/unit/data/test_satellite.py
@@ -62,7 +62,7 @@ def test_satellite_download_backup(small_satellite_data,
                                 satellite_backup_source_file_path=local_satellite_backup_path)
 
 
-def test_check_model_satellite_inputs_available(config_filename) -> None:
+def test_check_model_satellite_inputs_available(config_filename, config_india_sat_filename) -> None:
     """Check satellite availability across full coverage, delay, and gap scenarios."""
     t0 = pd.Timestamp("2023-01-01 00:00")
     sat_datetime_1 = pd.date_range(
@@ -77,20 +77,29 @@ def test_check_model_satellite_inputs_available(config_filename) -> None:
     )
     sat_datetime_3 = pd.date_range(
         t0 - pd.Timedelta("120min"),
+        t0 - pd.Timedelta("30min"),
+        freq="15min",
+    )
+    sat_datetime_4 = pd.date_range(
+        t0 - pd.Timedelta("120min"),
         t0 - pd.Timedelta("35min"),
         freq="5min",
     )
-    sat_datetime_4 = pd.to_datetime([t for t in sat_datetime_1 if t != t0 - pd.Timedelta("30min")])
-    sat_datetime_5 = pd.to_datetime([t for t in sat_datetime_1 if t != t0 - pd.Timedelta("60min")])
+
+    sat_datetime_5 = pd.to_datetime([t for t in sat_datetime_1 if t != t0 - pd.Timedelta("30min")])
+    sat_datetime_6 = pd.to_datetime([t for t in sat_datetime_1 if t != t0 - pd.Timedelta("60min")])
 
     assert check_model_satellite_inputs_available(config_filename, t0, sat_datetime_1, country="nl")
     assert check_model_satellite_inputs_available(config_filename, t0, sat_datetime_2, country="nl")
-    assert not check_model_satellite_inputs_available(
-        config_filename, t0, sat_datetime_3, country="nl",
+    assert check_model_satellite_inputs_available(
+        config_india_sat_filename, t0, sat_datetime_3, country="india",
     )
     assert not check_model_satellite_inputs_available(
         config_filename, t0, sat_datetime_4, country="nl",
     )
     assert not check_model_satellite_inputs_available(
         config_filename, t0, sat_datetime_5, country="nl",
+    )
+    assert not check_model_satellite_inputs_available(
+        config_filename, t0, sat_datetime_6, country="nl",
     )


### PR DESCRIPTION
# Pull Request

## Description

Changes include:
- Fixing the satellite data check to work for India as well as Europe satellite
- Adding relevant test for this and fixing tests
- Removing defaults for country and client_name, this is due to lots of logic being specific to a country and client so it's risky to have defaults, these should be passed explicitly instead
- Slight refactor to have more env variables collected at the beginning of the app

Fixes #207 and part of #206

## How Has This Been Tested?

Through local/CI tests and ran locally

Note we should update the [NL forecast dag in airflow-dags](https://github.com/openclimatefix/airflow-dags/blob/main/src/airflow_dags/dags/uk/forecast-site-nl-dag.py#L38) to include `CLIENT_NAME` and `COUNTRY` so this doesn't break when the site-forecast-app version is upgraded
