### PR TITLE
fix: normalize site and location names to lowercase to ensure consist…

### DIFF
--- a/site_forecast_app/data/generation.py
+++ b/site_forecast_app/data/generation.py
@@ -39,6 +39,8 @@ async def fetch_generation_from_dp(
     if not site_name:
         return []
 
+    site_name = site_name.lower()
+
     async with get_dataplatform_client() as client:
         loc_map = await fetch_dp_location_map(client)
         loc_uuid = loc_map.get(site_name)

--- a/site_forecast_app/save/data_platform.py
+++ b/site_forecast_app/save/data_platform.py
@@ -403,6 +403,8 @@ async def save_forecast_to_dataplatform(
         log.error("client_location_name is None/empty — cannot save")
         raise ValueError("client_location_name is required to save to the Data Platform")
 
+    client_location_name = client_location_name.lower()
+
     init_time_utc = ensure_timezone_aware(init_time_utc)
     log.info(
         f"location={client_location_name!r}  "


### PR DESCRIPTION
# Pull Request

## Description

Normalizes site and client location names to lowercase prior to making queries or storing records in the Data Platform. 

**Motivation and Context:**
The Data Platform enforces strict name validation for locations (requiring them to be all-lowercase, alphanumeric characters, underscores, and pipes). When sites in the local database contain uppercase letters (e.g., `ad_AP250`), attempts to save or retrieve forecast/generation data fail:
1. Creating a new location throws a gRPC validation error: `INVALID_ARGUMENT: validation error: location_name: ... lowercase, alphanumeric and underscores and pipes only`.
2. Retrieving existing locations or fetching historical generation data fails to match the pre-fetched `loc_map` keys because the Data Platform returns lowercase name mappings.

This change lowercases both `site_name` in `fetch_generation_from_dp` and `client_location_name` in `save_forecast_to_dataplatform` to resolve the mismatch and prevent validation failures.

No new dependencies are required.

Fixes #

## How Has This Been Tested?

- Run unit tests locally using `pytest tests/unit`, which completed successfully (70 passed).
- Executed the forecast run pipeline with site configurations containing uppercase letters (e.g., `ad_aeml_250mw`) and verified it mapped, saved, and completed the Data Platform integration successfully without gRPC validation errors with Dev DP.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
