### PR TITLE
chore: normalize client location naming

### DIFF
--- a/site_forecast_app/save/data_platform.py
+++ b/site_forecast_app/save/data_platform.py
@@ -271,6 +271,7 @@ async def create_new_location(
     lon, lat = longitude or 0.0, latitude or 0.0
     wkt = f"POINT ({lon} {lat})"
     capacity_watts = int(capacity_kw * 1000)
+    client_location_name = client_location_name.lower().replace("-", "_")
 
     try:
         create_req = dp.CreateLocationRequest(


### PR DESCRIPTION
# Pull Request

## Description

Normalizes `client_location_name` to lowercase and replaces hyphens with underscores before creating a new location on the Data Platform.

The Data Platform enforces a naming convention that only allows lowercase alphanumeric characters, underscores, and pipes. Previously, names containing uppercase letters or hyphens (e.g. `ad-AP250`) would fail validation at the gRPC level with a `NOT_FOUND` or validation error. This change ensures the name is sanitized at the point of use, in `create_new_location()` in `data_platform.py`, before it is sent to the Data Platform.

Fixes #

## How Has This Been Tested?

- [x] Yes

Manually verified that a location name containing uppercase letters and hyphens (e.g. `ad-AP250`) is correctly normalized to `ad_ap250` before the gRPC `CreateLocationRequest` is made, and the location is successfully created.

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings

