### PR TITLE
fix: add dp_location_name to models and update saving logic for forecasts

### DIFF
--- a/site_forecast_app/models/all_models.yaml
+++ b/site_forecast_app/models/all_models.yaml
@@ -275,6 +275,9 @@ models:
     id: openclimatefix-models/windnet_india
     version: ff50642bc8032c11f762d619dad0bb3f66b8a70b
     client: ruvnl
+    asset_type: wind
+    location_type: state
+    dp_location_name: ruvnl_wind
     satellite_archive_version: v0
   - name: windnet_gencast_ecmwf_v1
     type: pvnet
@@ -282,6 +285,8 @@ models:
     version: 76142c4828a0c5bd04e7648059fe2976bb2cfa40
     client: ruvnl
     asset_type: wind
+    location_type: state
+    dp_location_name: ruvnl_wind
     satellite_archive_version: v0
   - name: windnet_ecmwf_v0
     type: pvnet
@@ -289,4 +294,6 @@ models:
     version: 70e00da617d1a78f4d6c0fa8441993532fab0edd
     client: ruvnl
     asset_type: wind
+    location_type: state
+    dp_location_name: ruvnl_wind
     satellite_archive_version: v0

--- a/site_forecast_app/models/pydantic_models.py
+++ b/site_forecast_app/models/pydantic_models.py
@@ -79,6 +79,14 @@ class Model(BaseModel):
         description="The type of location the model is for (site, state, or nation)",
     )
 
+    dp_location_name: str | None = Field(
+        None,
+        title="Data Platform Location Name",
+        description="The Data Platform location that forecasts are saved to. "
+        "When unset, each site's client_location_name is used. Only set this for "
+        "models that forecast a single location (e.g. a state-level aggregate).",
+    )
+
     summation_location_type: Literal["site", "state", "nation"] | None = Field(
         None,
         title="Summation Location Type",

--- a/site_forecast_app/save/data_platform.py
+++ b/site_forecast_app/save/data_platform.py
@@ -84,7 +84,11 @@ async def save_to_dataplatform(
     observer_name: str | None = None,
 ) -> None:
     """Save Forecast to Dataplatform."""
-    client_location_name = forecast_meta.get("client_location_name")
+    # The model config can pin the DP location to save to (e.g. the ruvnl_wind state
+    # location); otherwise the site's client_location_name is used
+    client_location_name = (
+        forecast_meta.get("dp_location_name") or forecast_meta.get("client_location_name")
+    )
     model_tag = ml_model_name if ml_model_name else "default-model"
     init_time_utc = forecast_meta["timestamp_utc"]
     capacity_kw = forecast_meta.get("capacity_kw")

--- a/site_forecast_app/save/save.py
+++ b/site_forecast_app/save/save.py
@@ -81,6 +81,7 @@ def save_forecast_for_site_group(
                 "longitude": site.longitude,
                 "location_type": determine_location_type(site, model_config),
                 "energy_source": determine_energy_source(site),
+                "dp_location_name": model_config.dp_location_name if model_config else None,
             },
             "values": forecast_values[site.ml_id],
         }
@@ -140,6 +141,7 @@ def save_forecast(
         "longitude": forecast["meta"].get("longitude"),
         "location_type": forecast["meta"].get("location_type"),
         "energy_source": forecast["meta"].get("energy_source", dp.EnergySource.SOLAR),
+        "dp_location_name": forecast["meta"].get("dp_location_name"),
     }
 
     forecast_values_df = pd.DataFrame(forecast["values"])

--- a/tests/end_to_end/test_app.py
+++ b/tests/end_to_end/test_app.py
@@ -175,7 +175,7 @@ def test_app_ruvnl(
     result = run_click_script(app, args)
     assert result.exit_code == 0
 
-    n = 2  # 1 site, 2 models with GenCast data
+    n = 3  # 1 site, 3 wind models (2 GenCast + 1 ECMWF)
     assert db_session.query(ForecastSQL).count() == init_n_forecasts + n * 2
     assert db_session.query(MLModelSQL).count() == n * 2
     forecast_values = db_session.query(ForecastValueSQL).all()


### PR DESCRIPTION
# Pull Request

## Description

- added `dp_location_name` to models
- with this, we can save the forecasts to a certain location

Fixes #https://github.com/openclimatefix/client-private/issues/546

## How Has This Been Tested?

- [ ] with dev data-platform

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
