### PR TITLE
pin CI to v1.9.0

### DIFF
--- a/.github/workflows/branch_ci.yml
+++ b/.github/workflows/branch_ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   branch-ci:
-    uses: openclimatefix/.github/.github/workflows/nondefault_branch_push_ci_python.yml@main
+    uses: openclimatefix/.github/.github/workflows/nondefault_branch_push_ci_python.yml@v1.9.0
     secrets: inherit
     with:
       enable_linting: true

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   merged-ci:
-    uses: openclimatefix/.github/.github/workflows/default_branch_pr_merged_ci.yml@main
+    uses: openclimatefix/.github/.github/workflows/default_branch_pr_merged_ci.yml@v1.9.0
     secrets: inherit
 


### PR DESCRIPTION
# Pull Request

## Description

Lets pin the CI to v1.9.0 for the moment, and then we can upgrade it soon. This means CI is passing and other features can go through

## How Has This Been Tested?

- [x] CI on this PR

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
