### PR TITLE
limit by 4 another interpolation

### DIFF
--- a/site_forecast_app/data/generation.py
+++ b/site_forecast_app/data/generation.py
@@ -225,8 +225,8 @@ async def _get_site_generation_data(
         generation_df = generation_df.reindex(contiguous_dt_idx, fill_value=None)
 
         # Interpolate NaNs
-        generation_df = generation_df.interpolate(method="linear", 
-                                                  limit_direction="both", 
+        generation_df = generation_df.interpolate(method="linear",
+                                                  limit_direction="both",
                                                   limit=4)
 
         # Down-sample from 3 min to 15 min intervals

--- a/site_forecast_app/data/generation.py
+++ b/site_forecast_app/data/generation.py
@@ -225,6 +225,7 @@ async def _get_site_generation_data(
         generation_df = generation_df.reindex(contiguous_dt_idx, fill_value=None)
 
         # Interpolate NaNs
+        # this will do 4 steps, so 12 mins if 3 mins data, or 1 hour if 15 minute data
         generation_df = generation_df.interpolate(method="linear",
                                                   limit_direction="both",
                                                   limit=4)
@@ -233,6 +234,7 @@ async def _get_site_generation_data(
         generation_df = generation_df.resample("15min").mean()
 
         # Add a final row for t0, and interpolate this row
+        # this will do 4 steps, 1 hour if 15 minute data
         generation_df.loc[timestamp] = np.nan
         generation_df = generation_df.interpolate(method="quadratic",
                                                   fill_value="extrapolate",

--- a/site_forecast_app/data/generation.py
+++ b/site_forecast_app/data/generation.py
@@ -225,7 +225,9 @@ async def _get_site_generation_data(
         generation_df = generation_df.reindex(contiguous_dt_idx, fill_value=None)
 
         # Interpolate NaNs
-        generation_df = generation_df.interpolate(method="linear", limit_direction="both")
+        generation_df = generation_df.interpolate(method="linear", 
+                                                  limit_direction="both", 
+                                                  limit=4)
 
         # Down-sample from 3 min to 15 min intervals
         generation_df = generation_df.resample("15min").mean()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,7 @@ def sites(db_session):
 def generation_db_values(db_session, sites, init_timestamp):
     """Create some fake generations"""
 
-    n = int(20 * 48)  # 48 hours of readings
+    n = 20 * 48  # 48 hours of readings
     start_times = [init_timestamp - dt.timedelta(minutes=x * 3) for x in range(n)]
 
     # remove some of the most recent readings (to simulate missing timestamps)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,7 @@ def sites(db_session):
 def generation_db_values(db_session, sites, init_timestamp):
     """Create some fake generations"""
 
-    n = 450  # 22.5 hours of readings
+    n = int(20 * 48)  # 48 hours of readings
     start_times = [init_timestamp - dt.timedelta(minutes=x * 3) for x in range(n)]
 
     # remove some of the most recent readings (to simulate missing timestamps)

--- a/tests/integration/data/test_generation_integration.py
+++ b/tests/integration/data/test_generation_integration.py
@@ -56,6 +56,7 @@ def test_get_generation_data_dp(mock_fetch, db_session, sites, init_timestamp):
     """Test reading generation data from the data platform via env var."""
     mock_fetch.return_value = [
         (init_timestamp - dt.timedelta(hours=1), 10.5),
+        (init_timestamp - dt.timedelta(hours=0.5), 14.5),
         (init_timestamp, 20.0),
     ]
 


### PR DESCRIPTION
# Pull Request

## Description

Limit generation interpolation. We want the foreacst to fail if the generation data is delayed
#225 

## How Has This Been Tested?

- [x] CI test
- [x] locally ran model, but loaded less generation data and confirmed model failed
## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
