### PR TITLE
Add env var to stop saving to site-db

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ COPY --from=build-app /app/site_forecast_app /app/site_forecast_app
 # This is just a check to make sure it works, we've had problems with this in the past
 ENV PATH="/app/.venv/bin:${PATH}"
 
-ENTRYPOINT ["python","app/site_forecast_app/app.py", "--write-to-db"]
+ENTRYPOINT ["python","app/site_forecast_app/app.py"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The following environment variables are required to run the app:
 - `SATELLITE_SCALE_FACTOR`: The scale factor for the satellite data. Defaults to 1023 
 - `SATELLITE_BACKUP_ZARR_PATH`: Back up satellite data source. Defaults to None 
 - `READ_FROM_DATA_PLATFORM`: Whether to fetch generation data from the Data Platform instead of the database. Defaults to `false`.
+- `SAVE_TO_DATA_PLATFORM`: Whether to save forecasts to the Data Platform. Defaults to `false`.
+- `WRITE_TO_DB`: Whether to save forecasts to the site database. Defaults to `true`.
 - `ADJUSTER_LIMIT_FRACTION`: The limit of the adjuster in a fraction of the capacity. Default is 0.1
 - `ADJUSTER_LIMIT_MW`: The limit of the adjuster in MW. Default in 1000 MW
 - `RUN_BLEND_SERVICE`: Option to run the blend service or not. Default is true. 
@@ -107,9 +109,15 @@ DB_URL={DB_URL} poetry run seeder
 ```
 ⚠️ Note this is a destructive script and will drop all tables before recreating them to ensure a clean slate. DO NOT RUN IN PRODUCTION ENVIRONMENTS
 
-This example runs the application and writes the results to stdout
+This example runs the application and writes the results to the database
 ```
 DB_URL={DB_URL} NWP_ZARR_PATH={NWP_ZARR_PATH} poetry run app
+```
+
+⚠️ Writing to the database is the default. Pass `--no-write-to-db` (or set `WRITE_TO_DB=false`)
+to run without saving anything, which is what you usually want when pointing at a real database.
+```
+DB_URL={DB_URL} NWP_ZARR_PATH={NWP_ZARR_PATH} poetry run app --no-write-to-db
 ```
 
 To save batches, you need to set the `SAVE_BATCHES_DIR` environment variable to directory. 

--- a/README.md
+++ b/README.md
@@ -109,15 +109,9 @@ DB_URL={DB_URL} poetry run seeder
 ```
 ⚠️ Note this is a destructive script and will drop all tables before recreating them to ensure a clean slate. DO NOT RUN IN PRODUCTION ENVIRONMENTS
 
-This example runs the application and writes the results to the database
+This example runs the application and writes the results to stdout
 ```
 DB_URL={DB_URL} NWP_ZARR_PATH={NWP_ZARR_PATH} poetry run app
-```
-
-⚠️ Writing to the database is the default. Pass `--no-write-to-db` (or set `WRITE_TO_DB=false`)
-to run without saving anything, which is what you usually want when pointing at a real database.
-```
-DB_URL={DB_URL} NWP_ZARR_PATH={NWP_ZARR_PATH} poetry run app --no-write-to-db
 ```
 
 To save batches, you need to set the `SAVE_BATCHES_DIR` environment variable to directory. 

--- a/site_forecast_app/app.py
+++ b/site_forecast_app/app.py
@@ -139,10 +139,11 @@ def run_model(model: PVNetModel, timestamp: pd.Timestamp) -> dict | None:
 Format should be YYYY-MM-DD-HH-mm. Defaults to "now".',
 )
 @click.option(
-    "--write-to-db",
-    is_flag=True,
-    default=False,
-    help="Set this flag to actually write the results to the database.",
+    "--write-to-db/--no-write-to-db",
+    default=True,
+    help="Whether to write the results to the site database.",
+    show_default=True,
+    envvar="WRITE_TO_DB",
 )
 @click.option(
     "--log-level",
@@ -171,7 +172,7 @@ def app(timestamp: dt.datetime | None,
 
 def app_run(
     timestamp: dt.datetime | None,
-    write_to_db: bool = False,
+    write_to_db: bool = True,
     log_level: str = "info",
     use_adjuster_database: bool = True,
 ) -> None:
@@ -200,6 +201,13 @@ def app_run(
 
     log.info(f"Country {country}...")
     log.info(f"write_to_db {write_to_db}...")
+    log.info(f"save_to_data_platform {save_to_data_platform}...")
+
+    if not write_to_db and not save_to_data_platform:
+        log.warning(
+            "Both WRITE_TO_DB and SAVE_TO_DATA_PLATFORM are false, "
+            "so forecasts will not be saved anywhere.",
+        )
 
     with db_conn.get_session() as session:
         # 1. Load data/models

--- a/site_forecast_app/save/database.py
+++ b/site_forecast_app/save/database.py
@@ -83,8 +83,17 @@ def write_forecast_to_db(
 ) -> None:
     """Write a forecast dataframe to DB when enabled."""
     if not write_to_db:
+        log.info(
+            f"Not saving {ml_model_name} forecast for "
+            f"location_id={forecast_meta['location_uuid']} to the site database, "
+            "write_to_db is False",
+        )
         return
 
+    log.info(
+        f"Saving {ml_model_name} forecast for "
+        f"location_id={forecast_meta['location_uuid']} to the site database",
+    )
     insert_forecast_values(
         db_session,
         forecast_meta,

--- a/tests/end_to_end/test_app.py
+++ b/tests/end_to_end/test_app.py
@@ -18,11 +18,10 @@ from tests.end_to_end._utils import run_click_script
 now = pd.Timestamp.now().floor("15min") + pd.Timedelta(minutes=1)
 
 
-def _base_args(write_to_db: bool = False) -> list[str]:
+def _base_args(write_to_db: bool = True) -> list[str]:
     """Build common CLI args for app tests."""
     args = ["--date", dt.datetime.now(tz=dt.UTC).strftime("%Y-%m-%d-%H-%M")]
-    if write_to_db:
-        args.append("--write-to-db")
+    args.append("--write-to-db" if write_to_db else "--no-write-to-db")
     return args
 
 


### PR DESCRIPTION
# Pull Request

## Description

- Added an env var `WRITE_TO_DB` to stop saving to the site-db
- defaults to true


Fixes #https://github.com/openclimatefix/client-private/issues/388

## How Has This Been Tested?

- [x] Tested with dev data-platform and site-db

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
