### PR TITLE
update so we use v1 satellite as main run

### DIFF
--- a/site_forecast_app/models/all_models.yaml
+++ b/site_forecast_app/models/all_models.yaml
@@ -65,7 +65,7 @@ models:
     observer_name: nednl_no_curtailment 
     # the generation data used for the adjuster
     observer_name_adjuster: nednl
-    satellite_archive_version: v0
+    satellite_archive_version: v1
   - name: nl_regional_2h_pv_ecmwf
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -83,29 +83,30 @@ models:
     observer_name: nednl_no_curtailment
     # the generation data used for the adjuster
     observer_name_adjuster: nednl
-    satellite_archive_version: v0
-  - name: nl_regional_pv_ecmwf_mo_sat
-    type: pvnet
-    id: openclimatefix-models/pvnet_nl
-    version: 570c62524ba46bac02eaef451ed83382bc997283
-    summation_id: openclimatefix-models/pvnet_nl
-    summation_version: f40884b26ebd91f4613374fe04b453d2cf60256d
-    client: nl
-    asset_type: pv
-    satellite_scaling_method: constant
-    site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
-    location_type: state
-    summation_location_type: nation
-    curtailment: true
-    # the generation data that is loaded
-    observer_name: nednl_no_curtailment
-    # the generation data used for the adjuster
-    observer_name_adjuster: nednl
-    # save the uncurtailed values too
-    save_uncurtailed: true
-    observer_name_uncurtailed_adjuster: nednl_no_curtailment
-    satellite_archive_version: v0
-    # Uncurtailed model below
+    satellite_archive_version: v1
+  # old model trained on v0 satellite
+  # - name: nl_regional_pv_ecmwf_mo_sat
+  #   type: pvnet
+  #   id: openclimatefix-models/pvnet_nl
+  #   version: 570c62524ba46bac02eaef451ed83382bc997283
+  #   summation_id: openclimatefix-models/pvnet_nl
+  #   summation_version: f40884b26ebd91f4613374fe04b453d2cf60256d
+  #   client: nl
+  #   asset_type: pv
+  #   satellite_scaling_method: constant
+  #   site_group_uuid: 418259c9-0a31-4df7-a657-e53df9623897
+  #   location_type: state
+  #   summation_location_type: nation
+  #   curtailment: true
+  #   # the generation data that is loaded
+  #   observer_name: nednl_no_curtailment
+  #   # the generation data used for the adjuster
+  #   observer_name_adjuster: nednl
+  #   # save the uncurtailed values too
+  #   save_uncurtailed: true
+  #   observer_name_uncurtailed_adjuster: nednl_no_curtailment
+  #   satellite_archive_version: v0
+  #   # Uncurtailed model below
   - name: nl_regional_ecmwf_mo_sat
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -140,7 +141,7 @@ models:
     observer_name: nednl_no_curtailment
     observer_name_adjuster: nednl
     is_critical: false
-    satellite_archive_version: v0
+    satellite_archive_version: v1
   - name: nl_regional_sat_only
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -192,7 +193,7 @@ models:
     observer_name: nednl_no_curtailment
     observer_name_adjuster: nednl
     is_critical: true
-    satellite_archive_version: v0
+    satellite_archive_version: v1
   - name: nl_regional_mo_only
     type: pvnet
     id: openclimatefix-models/pvnet_nl
@@ -209,8 +210,8 @@ models:
     observer_name: nednl_no_curtailment
     observer_name_adjuster: nednl
     is_critical: true
-    satellite_archive_version: v0
-  - name: nl_regional_pv_ecmwf_mo9_sat
+    satellite_archive_version: v1
+  - name: nl_regional_pv_ecmwf_mo_sat
     # This model is trained on generation data where we have removed the curtailment
     # Also only 9 MO variables have been used, these have been removed:
     # - downward_shortwave_radiation_flux_gl

--- a/site_forecast_app/models/all_models.yaml
+++ b/site_forecast_app/models/all_models.yaml
@@ -234,8 +234,11 @@ models:
     # the generation data used for the adjuster
     observer_name_adjuster: nednl
     curtailment: true
-    is_critical: false
+    is_critical: true
     satellite_archive_version: v1
+    # save the uncurtailed values too
+    save_uncurtailed: true
+    observer_name_uncurtailed_adjuster: nednl_no_curtailment
     # India models below
   - name: pvnet_ad_sites_satellite_ecmwf_long_site_history
     type: pvnet

--- a/tests/end_to_end/test_app.py
+++ b/tests/end_to_end/test_app.py
@@ -27,7 +27,7 @@ def _base_args(write_to_db: bool = True) -> list[str]:
 
 @freeze_time(now)
 @patch("site_forecast_app.curtailment.EntsoePandasClient")
-def test_app(
+def test_app_sat_v0(
     mock_entsoe_pandas_client,
     db_session,
     sites,  # noqa: ARG001
@@ -60,8 +60,8 @@ def test_app(
 
     fv_per_hour = 4  # 15 min resolution = 4 values per hour
     n_national_models = 2
-    n_regional_models = 9
-    n_uncurtailed_saves = 1  # nl_regional_pv_ecmwf_mo_sat saves uncurtailed forecasts too
+    n_regional_models = 3
+    n_uncurtailed_saves = 0  # nl_regional_pv_ecmwf_mo_sat saves uncurtailed forecasts too
     # each regional model writes 12 regional sites + 1 national summation = 13 forecasts
     n_forecasts = n_national_models + (n_regional_models + n_uncurtailed_saves) * 13
     n_models = n_national_models + n_regional_models + n_uncurtailed_saves
@@ -112,8 +112,8 @@ def test_app_sat_v1(
 
     fv_per_hour = 4  # 15 min resolution = 4 values per hour
     n_national_models = 0
-    n_regional_models = 2
-    n_uncurtailed_saves = 0  # nl_regional_pv_ecmwf_mo_sat saves uncurtailed forecasts too
+    n_regional_models = 7
+    n_uncurtailed_saves = 1  # nl_regional_pv_ecmwf_mo_sat saves uncurtailed forecasts too
     # each regional model writes 12 regional sites + 1 national summation = 13 forecasts
     n_forecasts = n_national_models + (n_regional_models + n_uncurtailed_saves) * 13
     n_models = n_national_models + n_regional_models + n_uncurtailed_saves

--- a/tests/unit/models/test_pydantic_models.py
+++ b/tests/unit/models/test_pydantic_models.py
@@ -6,12 +6,12 @@ from site_forecast_app.models.pydantic_models import Model, get_all_models
 def test_get_all_models():
     """Test for getting all models"""
     models = get_all_models(satellite_archive_version="v0")
-    assert len(models.models) == 20
+    assert len(models.models) == 14
 
 def test_get_all_models_satellite_v1():
     """Test for getting all models"""
     models = get_all_models(satellite_archive_version="v1")
-    assert len(models.models) == 2
+    assert len(models.models) == 7
 
 def test_site_group_uuid():
     """Test for setting site_group_uuid"""


### PR DESCRIPTION
# Pull Request

## Description

Move most models over to v1, so just a few backup ones are left on v0 satellite

Renamed `nl_regional_pv_ecmwf_mo9_sat` to `nl_regional_pv_ecmwf_mo_sat` and got rid of old model `nl_regional_pv_ecmwf_mo_sat`

https://github.com/openclimatefix/site-forecast-app/issues/237

This needs to be deployed with https://github.com/openclimatefix/airflow-dags/pull/775

## How Has This Been Tested?

- [x] Ci tests
- [x] checked that the accuracy of this model is less than (or the same) as the old model (nl_regional_pv_ecmwf_mo_sat)
-
<img width="2459" height="980" alt="Screenshot 2026-08-12 at 13 55 07" src="https://github.com/user-attachments/assets/43feb89c-ab2c-4166-b506-5e100eeb7ce9" />



## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
