### PR TITLE
Fix pvnet concurrent

### DIFF
--- a/site_forecast_app/models/pvnet/model.py
+++ b/site_forecast_app/models/pvnet/model.py
@@ -424,12 +424,12 @@ class PVNetModel:
 
         # reduce generation data to only whats needed
         start_generation_time = self.t0 - pd.Timedelta(
-            minutes=self.config["input_data"]["generation"]["interval_start_minutes"],
+            minutes=abs(self.config["input_data"]["generation"]["interval_start_minutes"]),
         ) - pd.Timedelta(minutes=1)
-        log.info(f"Reducing generation data to only what's needed: \
-                    from {start_generation_time} onwards")
-        generation_xr = generation_xr.sel(time_utc=
-                                          (generation_xr.time_utc >= start_generation_time))
+        log.info("Reducing generation data to only what's needed: "
+                 f"from {start_generation_time} onwards")
+        generation_xr = generation_xr.sel(
+            time_utc=(generation_xr.time_utc >= start_generation_time))
 
         # Save generation data & metadata as a single zarr file
         generation_xr_with_meta = format_generation_data(

--- a/site_forecast_app/models/pvnet/model.py
+++ b/site_forecast_app/models/pvnet/model.py
@@ -242,6 +242,8 @@ class PVNetModel:
             batch = self.dataset.get_sample(t0=timestamp)
             sample_t0 = timestamp
         except Exception:
+            # this can happen if there are still some nans in the generation data
+            # PVNetConcurrentDataset was not built to have nans in it
             sample_t0 = self.dataset.valid_t0_times[-1]
             batch = self.dataset.get_sample(t0=sample_t0)
             log.warning(
@@ -422,10 +424,12 @@ class PVNetModel:
 
         # reduce generation data to only whats needed
         start_generation_time = self.t0 - pd.Timedelta(
-            minutes=self.config["input_data"]["generation"]["interval_start_minutes"]
+            minutes=self.config["input_data"]["generation"]["interval_start_minutes"],
         ) - pd.Timedelta(minutes=1)
-        log.info(f"Reducing generation data to only what's needed: from {start_generation_time} onwards")
-        generation_xr = generation_xr.sel(time_utc=(generation_xr.time_utc >= start_generation_time))
+        log.info(f"Reducing generation data to only what's needed: \
+                    from {start_generation_time} onwards")
+        generation_xr = generation_xr.sel(time_utc=
+                                          (generation_xr.time_utc >= start_generation_time))
 
         # Save generation data & metadata as a single zarr file
         generation_xr_with_meta = format_generation_data(

--- a/site_forecast_app/models/pvnet/model.py
+++ b/site_forecast_app/models/pvnet/model.py
@@ -417,8 +417,15 @@ class PVNetModel:
             freq="15min",
         )
 
+        # this adds any missing timestamps, but nans stay as nans
         generation_xr = generation_xr.reindex(time_utc=forecast_timesteps, fill_value=0.00001)
-        log.info(forecast_timesteps)
+
+        # reduce generation data to only whats needed
+        start_generation_time = self.t0 - pd.Timedelta(
+            minutes=self.config["input_data"]["generation"]["interval_start_minutes"]
+        ) - pd.Timedelta(minutes=1)
+        log.info(f"Reducing generation data to only what's needed: from {start_generation_time} onwards")
+        generation_xr = generation_xr.sel(time_utc=(generation_xr.time_utc >= start_generation_time))
 
         # Save generation data & metadata as a single zarr file
         generation_xr_with_meta = format_generation_data(


### PR DESCRIPTION
# Pull Request

## Description

This is a fix for if there are nans in the all generation data, but not nans in the relevant generation data.

This happens becasue PVNetConcurrentDatatset only works if there are no nans in all the generation data.

Therefore we have trim the generation data, to only the relevant part for each model

Helps deal with - https://github.com/openclimatefix/ocf-data-sampler/issues/434

## How Has This Been Tested?

- [x] CI test
- [x] ran locally, to check it works (done on satellite v1 models)

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
